### PR TITLE
Implement mental status endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ node src/index.js
 - `GET  /api/users/me` – Retrieve the current user's profile.
 - `POST /api/checkins` – Submit a check-in entry.
 - `GET  /api/checkins/:childId` – Get check-ins for a specific child.
+- `POST /api/mental-status` – Submit a mental status entry.
+- `GET  /api/mental-status/:childId` – Get mental status logs for a child.
 
 Authentication is performed via Firebase ID tokens passed in the `Authorization` header.
 

--- a/src/controllers/mentalStatusController.js
+++ b/src/controllers/mentalStatusController.js
@@ -1,0 +1,35 @@
+const admin = require('../config/firebase');
+const db = admin.firestore();
+
+exports.submitEntry = async (req, res) => {
+  const { childId, status, notes } = req.body;
+  try {
+    const entry = {
+      childId,
+      status,
+      notes,
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    };
+    await db.collection('mentalStatus').add(entry);
+    res.status(201).json({ message: 'Entry recorded' });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getEntries = async (req, res) => {
+  const { childId } = req.params;
+  try {
+    const snapshot = await db
+      .collection('mentalStatus')
+      .where('childId', '==', childId)
+      .orderBy('timestamp', 'desc')
+      .get();
+    const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,14 @@ require('./config/firebase');
 
 const checkinsRoutes = require('./routes/checkins');
 const usersRoutes = require('./routes/users');
+const mentalRoutes = require('./routes/mentalStatus');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 app.use('/api/checkins', checkinsRoutes);
 app.use('/api/users', usersRoutes);
+app.use('/api/mental-status', mentalRoutes);
 
 app.get('/', (req, res) => {
   res.json({ status: 'Kids Faith Tracker API' });

--- a/src/routes/mentalStatus.js
+++ b/src/routes/mentalStatus.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const auth = require('../middlewares/authMiddleware');
+const controller = require('../controllers/mentalStatusController');
+
+const router = express.Router();
+
+router.post('/', auth, controller.submitEntry);
+router.get('/:childId', auth, controller.getEntries);
+
+module.exports = router;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -7,3 +7,12 @@ describe('API availability', () => {
     expect(res.statusCode).toEqual(200);
   });
 });
+
+describe('Auth middleware', () => {
+  it('should reject unauthorized mental status POST', async () => {
+    const res = await request(app)
+      .post('/api/mental-status')
+      .send({ childId: 'c1', status: 'ok' });
+    expect(res.statusCode).toEqual(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add mental status controller and routes
- update Express app to mount mental status routes
- document new endpoints in README
- test unauthorized mental status request

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb8fc52fc8327a8ee7013afd67da7