### PR TITLE
Improve env instructions and Firebase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Firebase service account path
-GOOGLE_APPLICATION_CREDENTIALS=path/to/serviceAccountKey.json
+GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/serviceAccountKey.json
 # Firebase project ID
 FIREBASE_PROJECT_ID=your-project-id
 # Express app port

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a Node.js Express backend integrated with Firebase Admi
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and update the Firebase credentials and project information.
+1. Copy `.env.example` to `.env`. Set `GOOGLE_APPLICATION_CREDENTIALS` to the full path of your Firebase service account JSON and update the `FIREBASE_PROJECT_ID`.
 2. Install dependencies with `npm install` (internet access required).
 3. Start the development server:
 

--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -1,15 +1,23 @@
 const admin = require('firebase-admin');
 const path = require('path');
+const fs = require('fs');
 require('dotenv').config();
 
 const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
 
 if (!serviceAccountPath) {
-  throw new Error('GOOGLE_APPLICATION_CREDENTIALS is not set');
+  throw new Error(
+    'GOOGLE_APPLICATION_CREDENTIALS is not set. Did you copy .env.example to .env and set the path to your Firebase service account key?'
+  );
+}
+
+const resolvedPath = path.resolve(serviceAccountPath);
+if (!fs.existsSync(resolvedPath)) {
+  throw new Error(`Service account file not found at: ${resolvedPath}`);
 }
 
 admin.initializeApp({
-  credential: admin.credential.cert(require(path.resolve(serviceAccountPath))),
+  credential: admin.credential.cert(require(resolvedPath)),
   projectId: process.env.FIREBASE_PROJECT_ID,
 });
 


### PR DESCRIPTION
## Summary
- give better instructions about setting `GOOGLE_APPLICATION_CREDENTIALS`
- update example `.env`
- validate service account path during Firebase initialization

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684fbd16c6a08327bad9099cb8b34edf