### PR TITLE
Implement auth middleware and role guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ node src/index.js
 - `GET  /api/mental-status/:childId` – Get mental status logs for a child.
 
 Authentication is performed via Firebase ID tokens passed in the `Authorization` header.
+The `authMiddleware` verifies the token and attaches the authenticated user's
+claims to `req.user`. The optional `roleGuard` middleware restricts access to
+routes based on custom `role` claims (`parent`, `child`, or `mentor`).
 
 ## Testing
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,9 +7,9 @@
 - [x] Set up Express app with routes structure
 
 ## 🔐 Authentication Middleware
-- [ ] Verify Firebase ID Token
-- [ ] Role-based access check (parent, child, mentor)
-- [ ] Middleware: `authMiddleware.js`, `roleGuard.js`
+- [x] Verify Firebase ID Token
+- [x] Role-based access check (parent, child, mentor)
+- [x] Middleware: `authMiddleware.js`, `roleGuard.js`
 
 ## 👤 User Management
 - [ ] POST `/api/users/register-parent` – Create parent account (Firebase Auth)

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -8,7 +8,9 @@ async function authMiddleware(req, res, next) {
   const token = authHeader.split(' ')[1];
   try {
     const decoded = await admin.auth().verifyIdToken(token);
-    req.user = decoded;
+    // get custom claims in case the token doesn't include them yet
+    const userRecord = await admin.auth().getUser(decoded.uid);
+    req.user = { ...decoded, ...userRecord.customClaims };
     next();
   } catch (err) {
     console.error('Auth error', err);

--- a/src/middlewares/roleGuard.js
+++ b/src/middlewares/roleGuard.js
@@ -1,4 +1,8 @@
 function roleGuard(roles = []) {
+  if (!Array.isArray(roles)) {
+    roles = [roles];
+  }
+
   return (req, res, next) => {
     if (!req.user || !req.user.role || !roles.includes(req.user.role)) {
       return res.status(403).json({ message: 'Forbidden' });


### PR DESCRIPTION
## Summary
- verify Firebase ID tokens in `authMiddleware`
- fetch custom role claims
- allow `roleGuard` to accept single string or array
- document auth middleware in README
- check off auth tasks in TODO

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a15d416a08327a0c200801f75e2c6