### PR TITLE
Implement mentor linking routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ node src/index.js
 - `GET  /api/checkins/:childId` – Get check-ins for a specific child.
 - `POST /api/mental-status` – Submit a mental status entry.
 - `GET  /api/mental-status/:childId` – Get mental status logs for a child.
+- `GET  /api/children/:childId` – Get a child's profile and mentors.
+- `POST /api/mentors/assign` – Assign a mentor to a child (parent only).
+- `GET  /api/mentors/:mentorId/children` – List children assigned to a mentor.
 
 Authentication is performed via Firebase ID tokens passed in the `Authorization` header.
 The `authMiddleware` verifies the token and attaches the authenticated user's

--- a/TODO.md
+++ b/TODO.md
@@ -17,9 +17,9 @@
 - [x] GET `/api/users/me` – Get current user profile
 
 ## 👨‍👩‍👧 Child & Mentor Linking
-- [ ] GET `/api/children/:childId` – Get child profile & linked data
-- [ ] POST `/api/mentors/assign` – Assign mentor to child
-- [ ] GET `/api/mentors/:mentorId/children` – List assigned children
+ - [x] GET `/api/children/:childId` – Get child profile & linked data
+ - [x] POST `/api/mentors/assign` – Assign mentor to child
+ - [x] GET `/api/mentors/:mentorId/children` – List assigned children
 
 ## 📆 Daily Check-Ins
 - [ ] POST `/api/checkins` – Submit check-in

--- a/src/controllers/childrenController.js
+++ b/src/controllers/childrenController.js
@@ -1,0 +1,24 @@
+const admin = require('../config/firebase');
+const db = admin.firestore();
+
+exports.getChildProfile = async (req, res) => {
+  const { childId } = req.params;
+  try {
+    const userRecord = await admin.auth().getUser(childId);
+    const mentorSnapshot = await db
+      .collection('mentorAssignments')
+      .where('childId', '==', childId)
+      .get();
+    const mentors = mentorSnapshot.docs.map((d) => d.data().mentorId);
+
+    res.json({
+      uid: userRecord.uid,
+      email: userRecord.email,
+      displayName: userRecord.displayName,
+      mentors,
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/controllers/mentorsController.js
+++ b/src/controllers/mentorsController.js
@@ -1,0 +1,28 @@
+const admin = require('../config/firebase');
+const db = admin.firestore();
+
+exports.assignMentor = async (req, res) => {
+  const { mentorId, childId } = req.body;
+  try {
+    await db.collection('mentorAssignments').add({ mentorId, childId });
+    res.status(201).json({ message: 'Mentor assigned' });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getChildren = async (req, res) => {
+  const { mentorId } = req.params;
+  try {
+    const snapshot = await db
+      .collection('mentorAssignments')
+      .where('mentorId', '==', mentorId)
+      .get();
+    const children = snapshot.docs.map((d) => d.data().childId);
+    res.json(children);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ require('./config/firebase'); // make sure this file exists
 const checkinsRoutes = require('./routes/checkins');
 const usersRoutes = require('./routes/users');
 const mentalRoutes = require('./routes/mentalStatus');
+const childrenRoutes = require('./routes/children');
+const mentorsRoutes = require('./routes/mentors');
 
 const app = express();
 app.use(cors());
@@ -13,6 +15,8 @@ app.use(express.json());
 app.use('/api/checkins', checkinsRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/mental-status', mentalRoutes);
+app.use('/api/children', childrenRoutes);
+app.use('/api/mentors', mentorsRoutes);
 
 app.get('/', (req, res) => {
   res.json({ status: 'Kids Faith Tracker API' });

--- a/src/routes/children.js
+++ b/src/routes/children.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const auth = require('../middlewares/authMiddleware');
+const controller = require('../controllers/childrenController');
+
+const router = express.Router();
+
+router.get('/:childId', auth, controller.getChildProfile);
+
+module.exports = router;

--- a/src/routes/mentors.js
+++ b/src/routes/mentors.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const auth = require('../middlewares/authMiddleware');
+const roleGuard = require('../middlewares/roleGuard');
+const controller = require('../controllers/mentorsController');
+
+const router = express.Router();
+
+router.post('/assign', auth, roleGuard(['parent']), controller.assignMentor);
+router.get('/:mentorId/children', auth, controller.getChildren);
+
+module.exports = router;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -20,4 +20,21 @@ describe('Auth middleware', () => {
     const res = await request(app).get('/api/users/me');
     expect(res.statusCode).toEqual(401);
   });
+
+  it('should reject unauthorized child profile request', async () => {
+    const res = await request(app).get('/api/children/child1');
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized mentor assignment', async () => {
+    const res = await request(app)
+      .post('/api/mentors/assign')
+      .send({ childId: 'c1', mentorId: 'm1' });
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized mentor children request', async () => {
+    const res = await request(app).get('/api/mentors/m1/children');
+    expect(res.statusCode).toEqual(401);
+  });
 });


### PR DESCRIPTION
## Summary
- add routes to look up children and link mentors
- register new routes in the Express app
- document mentor linking endpoints in the README
- mark mentor linking TODO items as done
- extend tests for new routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a19b7ea848327a602a7412ca61774