### PR TITLE
Implement quizzes and essays endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ node src/index.js
 - `GET  /api/children/:childId` – Get a child's profile and mentors.
 - `POST /api/mentors/assign` – Assign a mentor to a child (parent only).
 - `GET  /api/mentors/:mentorId/children` – List children assigned to a mentor.
+- `GET  /api/quizzes/today` – Get today’s quiz.
+- `POST /api/quizzes/submit` – Submit quiz answers.
+- `GET  /api/quizzes/history/:childId` – Quiz history.
+- `POST /api/essays` – Create or update essay status.
+- `GET  /api/essays/:childId` – Get essay progress.
 
 Authentication is performed via Firebase ID tokens passed in the `Authorization` header.
 The `authMiddleware` verifies the token and attaches the authenticated user's

--- a/TODO.md
+++ b/TODO.md
@@ -30,13 +30,13 @@
  - [x] GET `/api/mental-status/:childId` – Retrieve mental logs
 
 ## 📖 Bible Quizzes
-- [ ] GET `/api/quizzes/today` – Get today’s quiz
-- [ ] POST `/api/quizzes/submit` – Submit quiz answers
-- [ ] GET `/api/quizzes/history/:childId` – Quiz history
+- [x] GET `/api/quizzes/today` – Get today’s quiz
+- [x] POST `/api/quizzes/submit` – Submit quiz answers
+- [x] GET `/api/quizzes/history/:childId` – Quiz history
 
 ## 📝 Essays
-- [ ] POST `/api/essays` – Create or update essay status
-- [ ] GET `/api/essays/:childId` – Get essay progress
+- [x] POST `/api/essays` – Create or update essay status
+- [x] GET `/api/essays/:childId` – Get essay progress
 
 ## 📚 School Work
 - [ ] POST `/api/schoolwork` – Submit score and help flag

--- a/src/controllers/essaysController.js
+++ b/src/controllers/essaysController.js
@@ -1,0 +1,32 @@
+const admin = require('../config/firebase');
+const db = admin.firestore();
+
+exports.createOrUpdate = async (req, res) => {
+  const { childId, status } = req.body;
+  try {
+    const entry = {
+      childId,
+      status,
+      updated: admin.firestore.FieldValue.serverTimestamp(),
+    };
+    await db.collection('essays').doc(childId).set(entry, { merge: true });
+    res.status(201).json({ message: 'Essay status updated' });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getProgress = async (req, res) => {
+  const { childId } = req.params;
+  try {
+    const doc = await db.collection('essays').doc(childId).get();
+    if (!doc.exists) {
+      return res.json(null);
+    }
+    res.json({ id: doc.id, ...doc.data() });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/controllers/quizzesController.js
+++ b/src/controllers/quizzesController.js
@@ -1,0 +1,49 @@
+const admin = require('../config/firebase');
+const db = admin.firestore();
+
+exports.getTodayQuiz = async (req, res) => {
+  const today = new Date().toISOString().split('T')[0];
+  try {
+    const doc = await db.collection('quizzes').doc(today).get();
+    if (!doc.exists) {
+      return res.status(404).json({ message: 'Quiz not found' });
+    }
+    res.json({ id: doc.id, ...doc.data() });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.submitQuiz = async (req, res) => {
+  const { childId, quizId, answers } = req.body;
+  try {
+    const entry = {
+      childId,
+      quizId,
+      answers,
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    };
+    await db.collection('quizSubmissions').add(entry);
+    res.status(201).json({ message: 'Quiz submitted' });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getHistory = async (req, res) => {
+  const { childId } = req.params;
+  try {
+    const snapshot = await db
+      .collection('quizSubmissions')
+      .where('childId', '==', childId)
+      .orderBy('timestamp', 'desc')
+      .get();
+    const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ const usersRoutes = require('./routes/users');
 const mentalRoutes = require('./routes/mentalStatus');
 const childrenRoutes = require('./routes/children');
 const mentorsRoutes = require('./routes/mentors');
+const quizzesRoutes = require('./routes/quizzes');
+const essaysRoutes = require('./routes/essays');
 
 const app = express();
 app.use(cors());
@@ -17,6 +19,8 @@ app.use('/api/users', usersRoutes);
 app.use('/api/mental-status', mentalRoutes);
 app.use('/api/children', childrenRoutes);
 app.use('/api/mentors', mentorsRoutes);
+app.use('/api/quizzes', quizzesRoutes);
+app.use('/api/essays', essaysRoutes);
 
 app.get('/', (req, res) => {
   res.json({ status: 'Kids Faith Tracker API' });

--- a/src/routes/essays.js
+++ b/src/routes/essays.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const auth = require('../middlewares/authMiddleware');
+const controller = require('../controllers/essaysController');
+
+const router = express.Router();
+
+router.post('/', auth, controller.createOrUpdate);
+router.get('/:childId', auth, controller.getProgress);
+
+module.exports = router;

--- a/src/routes/quizzes.js
+++ b/src/routes/quizzes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const auth = require('../middlewares/authMiddleware');
+const controller = require('../controllers/quizzesController');
+
+const router = express.Router();
+
+router.get('/today', auth, controller.getTodayQuiz);
+router.post('/submit', auth, controller.submitQuiz);
+router.get('/history/:childId', auth, controller.getHistory);
+
+module.exports = router;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -38,6 +38,35 @@ describe('Auth middleware', () => {
     expect(res.statusCode).toEqual(401);
   });
 
+  it('should reject unauthorized today quiz request', async () => {
+    const res = await request(app).get('/api/quizzes/today');
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized quiz submission', async () => {
+    const res = await request(app)
+      .post('/api/quizzes/submit')
+      .send({ childId: 'c1', quizId: 'q1', answers: [] });
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized quiz history request', async () => {
+    const res = await request(app).get('/api/quizzes/history/c1');
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized essay update', async () => {
+    const res = await request(app)
+      .post('/api/essays')
+      .send({ childId: 'c1', status: 'started' });
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized essay progress request', async () => {
+    const res = await request(app).get('/api/essays/c1');
+    expect(res.statusCode).toEqual(401);
+  });
+
   it('should reject unauthorized check-in submission', async () => {
     const res = await request(app)
       .post('/api/checkins')


### PR DESCRIPTION
## Summary
- add quizzes and essays controllers
- wire up quizzes and essays routes
- expose new routes in main app
- document new endpoints and mark TODO items complete
- extend auth tests to cover new endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a1ce0e7388327906df8bc10ca751a