### PR TITLE
Implement group endpoints and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This repository contains a Node.js Express backend integrated with Firebase Admi
 
 ## Setup
 
-1. Copy `.env.example` to `.env`. Set `GOOGLE_APPLICATION_CREDENTIALS` to the full path of your Firebase service account JSON and update the `FIREBASE_PROJECT_ID`.
-2. Install dependencies with `npm install` (internet access required).
+1. Copy `.env.example` to `.env`.
+   - `GOOGLE_APPLICATION_CREDENTIALS` should point to your Firebase service account JSON file.
+   - `FIREBASE_PROJECT_ID` must match your Firebase project.
+2. Install dependencies with `npm install` (requires internet access).
 3. Start the development server:
 
 ```bash
@@ -36,6 +38,10 @@ node src/index.js
 - `POST /api/points/grant` – Grant points.
 - `GET  /api/points/:childId` – Get points for a child.
 - `GET  /api/groups/:groupId/points` – Get total points for a group.
+- `POST /api/groups/create` – Create a group (max 5 members).
+- `POST /api/groups/add-member` – Add a child to a group.
+- `GET  /api/groups/:groupId` – View group info.
+- `GET  /api/groups` – List all groups (admin only).
 
 Authentication is performed via Firebase ID tokens passed in the `Authorization` header.
 The `authMiddleware` verifies the token and attaches the authenticated user's
@@ -44,7 +50,11 @@ routes based on custom `role` claims (`parent`, `child`, or `mentor`).
 
 ## Testing
 
-Run `npm test` once you have added test cases.
+This project uses **Jest**. After installing dependencies run:
+
+```bash
+npm test
+```
 
 ## Roadmap
 

--- a/TODO.md
+++ b/TODO.md
@@ -52,10 +52,10 @@
 - [x] GET `/api/groups/:groupId/points` – Group total points
 
 ## 👥 Groups
-- [ ] POST `/api/groups/create` – Create group (max 5 members)
-- [ ] POST `/api/groups/add-member` – Add child to group
-- [ ] GET `/api/groups/:groupId` – View group info and members
-- [ ] GET `/api/groups` – List all groups (admin use)
+- [x] POST `/api/groups/create` – Create group (max 5 members)
+- [x] POST `/api/groups/add-member` – Add child to group
+- [x] GET `/api/groups/:groupId` – View group info and members
+- [x] GET `/api/groups` – List all groups (admin use)
 
 ## 🔔 Notifications (Future Phase)
 - [ ] Trigger email or in-app alert for bullying flags
@@ -63,8 +63,8 @@
 - [ ] Reminder jobs for quiz, essay, project deadlines
 
 ## 🧪 Testing
-- [ ] Setup Jest or Mocha/Chai for unit tests
-- [ ] Write test cases for core routes and utilities
+ - [x] Setup Jest or Mocha/Chai for unit tests
+ - [ ] Write test cases for core routes and utilities
 
 ## 📄 Documentation
 - [ ] Create OpenAPI/Swagger spec for all endpoints

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,78 @@
+openapi: 3.0.0
+info:
+  title: Kids Faith Tracker API
+  version: 1.0.0
+paths:
+  /api/groups/create:
+    post:
+      summary: Create a new group
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                members:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - name
+      responses:
+        '201':
+          description: Group created
+  /api/groups/add-member:
+    post:
+      summary: Add a child to a group
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                groupId:
+                  type: string
+                childId:
+                  type: string
+              required:
+                - groupId
+                - childId
+      responses:
+        '200':
+          description: Child added
+  /api/groups/{groupId}:
+    get:
+      summary: Get group info
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: groupId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Group object
+  /api/groups:
+    get:
+      summary: List all groups
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Array of groups
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,8 @@
     "firebase-admin": "^11.10.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "jest": "^29.6.2",
+    "supertest": "^6.3.3"
   }
 }

--- a/src/controllers/groupsController.js
+++ b/src/controllers/groupsController.js
@@ -1,0 +1,75 @@
+const admin = require('../config/firebase');
+const db = admin.firestore();
+
+const MAX_MEMBERS = 5;
+
+exports.createGroup = async (req, res) => {
+  const { name, members = [] } = req.body;
+  if (!name) {
+    return res.status(400).json({ message: 'Group name required' });
+  }
+  if (members.length > MAX_MEMBERS) {
+    return res.status(400).json({ message: `Group can have max ${MAX_MEMBERS} members` });
+  }
+  try {
+    const docRef = await db.collection('groups').add({ name, members });
+    res.status(201).json({ id: docRef.id, name, members });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.addMember = async (req, res) => {
+  const { groupId, childId } = req.body;
+  if (!groupId || !childId) {
+    return res.status(400).json({ message: 'groupId and childId required' });
+  }
+  try {
+    const docRef = db.collection('groups').doc(groupId);
+    const doc = await docRef.get();
+    if (!doc.exists) {
+      return res.status(404).json({ message: 'Group not found' });
+    }
+    const data = doc.data();
+    const members = data.members || [];
+    if (members.includes(childId)) {
+      return res.status(400).json({ message: 'Child already in group' });
+    }
+    if (members.length >= MAX_MEMBERS) {
+      return res.status(400).json({ message: `Group can have max ${MAX_MEMBERS} members` });
+    }
+    members.push(childId);
+    await docRef.update({ members });
+    res.json({ id: groupId, name: data.name, members });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getGroup = async (req, res) => {
+  const { groupId } = req.params;
+  try {
+    const doc = await db.collection('groups').doc(groupId).get();
+    if (!doc.exists) {
+      return res.status(404).json({ message: 'Group not found' });
+    }
+    res.json({ id: doc.id, ...doc.data() });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.listGroups = async (req, res) => {
+  try {
+    const snapshot = await db.collection('groups').get();
+    const groups = snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+    res.json(groups);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+

--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -1,9 +1,15 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const roleGuard = require('../middlewares/roleGuard');
+const groupsController = require('../controllers/groupsController');
 const pointsController = require('../controllers/pointsController');
 
 const router = express.Router();
 
+router.post('/create', auth, groupsController.createGroup);
+router.post('/add-member', auth, groupsController.addMember);
+router.get('/:groupId', auth, groupsController.getGroup);
+router.get('/', auth, roleGuard('admin'), groupsController.listGroups);
 router.get('/:groupId/points', auth, pointsController.getGroupPoints);
 
 module.exports = router;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -78,4 +78,23 @@ describe('Auth middleware', () => {
     const res = await request(app).get('/api/checkins/c1');
     expect(res.statusCode).toEqual(401);
   });
+
+  it('should reject unauthorized group creation', async () => {
+    const res = await request(app)
+      .post('/api/groups/create')
+      .send({ name: 'Test' });
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized add member', async () => {
+    const res = await request(app)
+      .post('/api/groups/add-member')
+      .send({ groupId: 'g1', childId: 'c1' });
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized group info request', async () => {
+    const res = await request(app).get('/api/groups/g1');
+    expect(res.statusCode).toEqual(401);
+  });
 });


### PR DESCRIPTION
## Summary
- add groups controller
- define routes for creating groups and adding members
- set up Jest with supertest
- update README and TODO for new endpoints
- document groups in OpenAPI spec
- extend tests for group auth checks

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1f6ee6ac8327a3b53e36eae19ccc