### PR TITLE
Handle missing Firebase credentials during tests

### DIFF
--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -3,22 +3,25 @@ const path = require('path');
 const fs = require('fs');
 require('dotenv').config();
 
-const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+// During tests the Firebase module is mocked, so skip initialization.
+if (process.env.NODE_ENV !== 'test') {
+  const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
 
-if (!serviceAccountPath) {
-  throw new Error(
-    'GOOGLE_APPLICATION_CREDENTIALS is not set. Did you copy .env.example to .env and set the path to your Firebase service account key?'
-  );
+  if (!serviceAccountPath) {
+    throw new Error(
+      'GOOGLE_APPLICATION_CREDENTIALS is not set. Did you copy .env.example to .env and set the path to your Firebase service account key?'
+    );
+  }
+
+  const resolvedPath = path.resolve(serviceAccountPath);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Service account file not found at: ${resolvedPath}`);
+  }
+
+  admin.initializeApp({
+    credential: admin.credential.cert(require(resolvedPath)),
+    projectId: process.env.FIREBASE_PROJECT_ID,
+  });
 }
-
-const resolvedPath = path.resolve(serviceAccountPath);
-if (!fs.existsSync(resolvedPath)) {
-  throw new Error(`Service account file not found at: ${resolvedPath}`);
-}
-
-admin.initializeApp({
-  credential: admin.credential.cert(require(resolvedPath)),
-  projectId: process.env.FIREBASE_PROJECT_ID,
-});
 
 module.exports = admin;


### PR DESCRIPTION
## Summary
- skip Firebase initialization when `NODE_ENV` is `test`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a33fe75008327ae419961e64bbc97