### PR TITLE
Support legacy /api/mentor paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ app.use('/api/mental-status', mentalRoutes);
 app.use('/api/children', childrenRoutes);
 app.use('/api/mentors', mentorsRoutes);
 app.use('/api/mentors', mentorRecordsRoutes);
+// Support legacy singular `/api/mentor` paths used by older clients
+app.use('/api/mentor', mentorsRoutes);
+app.use('/api/mentor', mentorRecordsRoutes);
 app.use('/api/quizzes', quizzesRoutes);
 app.use('/api/bible-questions', bibleQuestionsRoutes);
 app.use('/api/essays', essaysRoutes);


### PR DESCRIPTION
## Summary
- support singular `/api/mentor` routes as aliases for `/api/mentors`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688584ba911083279dc5f75f32c06029