### PR TITLE
Add endpoint for listing group points

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ npm test
 - `POST /api/points/grant` – Grant points.
 - `GET  /api/points/:childId` – Get points for a child.
 - `GET  /api/groups/:groupId/points` – Get total points for a group.
+- `GET  /api/groups/points` – Get total points for all groups.
 - `POST /api/groups/create` – Create a group (max 5 members).
 - `POST /api/groups/add-member` – Add a child to a group.
 - `GET  /api/groups/:groupId` – View group info.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -312,6 +312,14 @@ paths:
        responses:
         '200':
           description: Child added
+  /api/groups/points:
+    get:
+      summary: List points for all groups
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Array of group point totals
   /api/groups/{groupId}:
     get:
       summary: Get group info

--- a/src/controllers/pointsController.js
+++ b/src/controllers/pointsController.js
@@ -56,3 +56,24 @@ exports.getGroupPoints = async (req, res) => {
     res.status(400).json({ message: err.message });
   }
 };
+
+exports.listGroupPoints = async (_req, res) => {
+  try {
+    const groupsSnap = await db.collection('groups').get();
+    const results = [];
+
+    for (const doc of groupsSnap.docs) {
+      const { members = [], name } = doc.data();
+      let total = 0;
+      for (const childId of members) {
+        total += await getChildTotal(childId);
+      }
+      results.push({ groupId: doc.id, name, total });
+    }
+
+    res.json(results);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -8,8 +8,9 @@ const router = express.Router();
 
 router.post('/create', auth, groupsController.createGroup);
 router.post('/add-member', auth, groupsController.addMember);
+router.get('/points', auth, pointsController.listGroupPoints);
+router.get('/:groupId/points', auth, pointsController.getGroupPoints);
 router.get('/:groupId', auth, groupsController.getGroup);
 router.get('/', auth, roleGuard('admin'), groupsController.listGroups);
-router.get('/:groupId/points', auth, pointsController.getGroupPoints);
 
 module.exports = router;

--- a/test/pointsController.test.js
+++ b/test/pointsController.test.js
@@ -1,0 +1,63 @@
+const groupsGetMock = jest.fn();
+const whereMock = jest.fn();
+const firestoreMock = {
+  collection: jest.fn((name) => {
+    if (name === 'groups') {
+      return { get: groupsGetMock };
+    }
+    if (name === 'points') {
+      return { where: whereMock };
+    }
+    return {};
+  }),
+};
+
+jest.mock('../src/config/firebase', () => ({
+  firestore: firestoreMock,
+  admin: {},
+}));
+
+const pointsController = require('../src/controllers/pointsController');
+
+function mockResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('pointsController.listGroupPoints', () => {
+  beforeEach(() => {
+    groupsGetMock.mockReset();
+    whereMock.mockReset();
+    firestoreMock.collection.mockClear();
+  });
+
+  it('aggregates totals for all groups', async () => {
+    groupsGetMock.mockResolvedValue({
+      docs: [
+        { id: 'g1', data: () => ({ members: ['c1'], name: 'G1' }) },
+        { id: 'g2', data: () => ({ members: ['c2', 'c3'], name: 'G2' }) },
+      ],
+    });
+
+    const pointsByChild = {
+      c1: [{ data: () => ({ amount: 10 }) }],
+      c2: [{ data: () => ({ amount: 5 }) }],
+      c3: [{ data: () => ({ amount: 2 }) }],
+    };
+
+    whereMock.mockImplementation((_field, _op, childId) => ({
+      get: jest.fn().mockResolvedValue({ docs: pointsByChild[childId] || [] }),
+    }));
+
+    const res = mockResponse();
+
+    await pointsController.listGroupPoints({}, res);
+
+    expect(res.json).toHaveBeenCalledWith([
+      { groupId: 'g1', name: 'G1', total: 10 },
+      { groupId: 'g2', name: 'G2', total: 7 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `GET /api/groups/points` to retrieve totals for all groups
- document new endpoint in README and OpenAPI spec
- implement `listGroupPoints` controller
- add unit test for the new controller

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688613d2b3388327afa9434e0e548160