### PR TITLE
Add SSE points stream

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -265,6 +265,22 @@ paths:
       responses:
         '200':
           description: Points object
+  /api/points/{childId}/stream:
+    get:
+      summary: Stream points for child
+      description: Server-sent events stream of point totals.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: childId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: SSE stream
+
   /api/groups/create:
     post:
       summary: Create a new group

--- a/src/routes/points.js
+++ b/src/routes/points.js
@@ -5,6 +5,7 @@ const pointsController = require('../controllers/pointsController');
 const router = express.Router();
 
 router.post('/grant', auth, pointsController.grantPoints);
+router.get('/:childId/stream', auth, pointsController.streamChildPoints);
 router.get('/:childId', auth, pointsController.getChildPoints);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add server-sent events stream for child points
- document new `/api/points/{childId}/stream` endpoint

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688bcb10c54c83279cce5887e3210731