### PR TITLE
Add child-parent access control for child pages

### DIFF
--- a/src/middlewares/childAccess.js
+++ b/src/middlewares/childAccess.js
@@ -1,0 +1,37 @@
+const { admin } = require('../config/firebase');
+
+// Middleware to ensure that the requester is either the child
+// referenced in the request or the parent of that child.
+// childId may be provided as a route param or in the request body.
+module.exports = async function childAccess(req, res, next) {
+  const childId = req.params.childId || req.body.childId;
+  if (!childId) {
+    return res.status(400).json({ message: 'childId required' });
+  }
+
+  const { role, uid } = req.user || {};
+
+  // Allow a child to access their own resources
+  if (role === 'child') {
+    if (uid === childId) {
+      return next();
+    }
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  // Allow a parent to access resources of their own child
+  if (role === 'parent') {
+    try {
+      const userRecord = await admin.auth().getUser(childId);
+      const claims = userRecord.customClaims || {};
+      if (claims.parentId === uid) {
+        return next();
+      }
+    } catch (err) {
+      console.error('childAccess error', err);
+      return res.status(400).json({ message: err.message });
+    }
+  }
+
+  return res.status(403).json({ message: 'Forbidden' });
+};

--- a/src/routes/checkins.js
+++ b/src/routes/checkins.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const childAccess = require('../middlewares/childAccess');
 const checkinsController = require('../controllers/checkinsController');
 
 const router = express.Router();
 
-router.post('/', auth, checkinsController.submitCheckin);
-router.get('/:childId', auth, checkinsController.getCheckins);
+router.post('/', auth, childAccess, checkinsController.submitCheckin);
+router.get('/:childId', auth, childAccess, checkinsController.getCheckins);
 
 module.exports = router;

--- a/src/routes/children.js
+++ b/src/routes/children.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const childAccess = require('../middlewares/childAccess');
 const controller = require('../controllers/childrenController');
 
 const router = express.Router();
 
-router.get('/:childId', auth, controller.getChildProfile);
+router.get('/:childId', auth, childAccess, controller.getChildProfile);
 
 module.exports = router;

--- a/src/routes/essays.js
+++ b/src/routes/essays.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const childAccess = require('../middlewares/childAccess');
 const controller = require('../controllers/essaysController');
 
 const router = express.Router();
 
-router.post('/', auth, controller.createOrUpdate);
-router.get('/:childId', auth, controller.getProgress);
+router.post('/', auth, childAccess, controller.createOrUpdate);
+router.get('/:childId', auth, childAccess, controller.getProgress);
 
 module.exports = router;

--- a/src/routes/mentalStatus.js
+++ b/src/routes/mentalStatus.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const childAccess = require('../middlewares/childAccess');
 const controller = require('../controllers/mentalStatusController');
 
 const router = express.Router();
 
-router.post('/', auth, controller.submitEntry);
-router.get('/:childId', auth, controller.getEntries);
+router.post('/', auth, childAccess, controller.submitEntry);
+router.get('/:childId', auth, childAccess, controller.getEntries);
 
 module.exports = router;

--- a/src/routes/points.js
+++ b/src/routes/points.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const childAccess = require('../middlewares/childAccess');
 const pointsController = require('../controllers/pointsController');
 
 const router = express.Router();
 
-router.post('/grant', auth, pointsController.grantPoints);
-router.get('/:childId/stream', auth, pointsController.streamChildPoints);
-router.get('/:childId', auth, pointsController.getChildPoints);
+router.post('/grant', auth, childAccess, pointsController.grantPoints);
+router.get('/:childId/stream', auth, childAccess, pointsController.streamChildPoints);
+router.get('/:childId', auth, childAccess, pointsController.getChildPoints);
 
 module.exports = router;

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const childAccess = require('../middlewares/childAccess');
 const projectsController = require('../controllers/projectsController');
 
 const router = express.Router();
 
-router.post('/', auth, projectsController.upsertProject);
-router.get('/:childId', auth, projectsController.getProjects);
+router.post('/', auth, childAccess, projectsController.upsertProject);
+router.get('/:childId', auth, childAccess, projectsController.getProjects);
 
 module.exports = router;

--- a/src/routes/quizzes.js
+++ b/src/routes/quizzes.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const childAccess = require('../middlewares/childAccess');
 const controller = require('../controllers/quizzesController');
 
 const router = express.Router();
 
 router.get('/today', auth, controller.getTodayQuiz);
-router.post('/submit', auth, controller.submitQuiz);
-router.get('/history/:childId', auth, controller.getHistory);
+router.post('/submit', auth, childAccess, controller.submitQuiz);
+router.get('/history/:childId', auth, childAccess, controller.getHistory);
 
 module.exports = router;

--- a/src/routes/schoolwork.js
+++ b/src/routes/schoolwork.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
+const childAccess = require('../middlewares/childAccess');
 const schoolworkController = require('../controllers/schoolworkController');
 
 const router = express.Router();
 
-router.post('/', auth, schoolworkController.submitEntry);
-router.get('/:childId', auth, schoolworkController.getEntries);
+router.post('/', auth, childAccess, schoolworkController.submitEntry);
+router.get('/:childId', auth, childAccess, schoolworkController.getEntries);
 
 module.exports = router;

--- a/test/childAccess.test.js
+++ b/test/childAccess.test.js
@@ -1,0 +1,54 @@
+const mockGetUser = jest.fn();
+
+jest.mock('../src/config/firebase', () => ({
+  admin: { auth: () => ({ getUser: mockGetUser }) },
+  __getUserMock: mockGetUser,
+}));
+
+const childAccess = require('../src/middlewares/childAccess');
+const { __getUserMock } = require('../src/config/firebase');
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('childAccess middleware', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    res = mockRes();
+    next = jest.fn();
+    __getUserMock.mockReset();
+  });
+
+  it('allows a child to access their own data', async () => {
+    req = { params: { childId: 'c1' }, user: { role: 'child', uid: 'c1' } };
+    await childAccess(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('blocks a child from accessing other child data', async () => {
+    req = { params: { childId: 'c2' }, user: { role: 'child', uid: 'c1' } };
+    await childAccess(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows a parent to access their child', async () => {
+    req = { params: { childId: 'c1' }, user: { role: 'parent', uid: 'p1' } };
+    __getUserMock.mockResolvedValue({ customClaims: { parentId: 'p1' } });
+    await childAccess(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("blocks a parent from accessing another parent's child", async () => {
+    req = { params: { childId: 'c1' }, user: { role: 'parent', uid: 'p2' } };
+    __getUserMock.mockResolvedValue({ customClaims: { parentId: 'p1' } });
+    await childAccess(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `childAccess` middleware verifying requests are made by the child or their parent
- Protect all child-specific routes with this middleware
- Test access control behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688eea5517fc8327bd919d9e10dc4815