### PR TITLE
Add child age tracking and mentor profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ npm test
 
 - `POST /api/users/register-parent` – Create a parent account.
 - `POST /api/users/register-admin` – Create an admin account.
-- `POST /api/users/add-child` – Add a child account (parent only).
+- `POST /api/users/add-child` – Add a child account with name and age (parent only).
 - `GET  /api/users/me` – Retrieve the current user's profile.
 - `POST /api/checkins` – Submit a check-in entry.
 - `GET  /api/checkins/:childId` – Get check-ins for a specific child.
 - `POST /api/mental-status` – Submit a mental status entry.
 - `GET  /api/mental-status/:childId` – Get mental status logs for a child.
-- `GET  /api/children/:childId` – Get a child's profile and mentors.
+- `GET  /api/children/:childId` – Get a child's profile, age and mentors.
+- `POST /api/mentors/create` – Add a mentor profile (admin only).
 - `POST /api/mentors/assign` – Assign a mentor to a child (parent only).
 - `GET  /api/mentors/:mentorId/children` – List children assigned to a mentor.
 - `POST /api/mentors/records` – Create a mentor progress note.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -23,6 +23,26 @@ paths:
       description: Parent role required.
       security:
         - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+                name:
+                  type: string
+                age:
+                  type: integer
+              required:
+                - email
+                - password
+                - name
+                - age
       responses:
         '201':
           description: Child created
@@ -217,6 +237,32 @@ paths:
       responses:
         '200':
           description: Array of entries
+  /api/mentors/create:
+    post:
+      summary: Create mentor profile
+      description: Admin role required.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+              required:
+                - name
+                - email
+                - phone
+      responses:
+        '201':
+          description: Mentor created
   /api/mentors/records:
     post:
       summary: Create mentor record

--- a/src/controllers/childrenController.js
+++ b/src/controllers/childrenController.js
@@ -5,6 +5,11 @@ exports.getChildProfile = async (req, res) => {
   const { childId } = req.params;
   try {
     const userRecord = await admin.auth().getUser(childId);
+    let age;
+    if (db) {
+      const childDoc = await db.collection('children').doc(childId).get();
+      age = childDoc.exists ? childDoc.data().age : undefined;
+    }
     const mentorSnapshot = await db
       .collection('mentorAssignments')
       .where('childId', '==', childId)
@@ -15,6 +20,7 @@ exports.getChildProfile = async (req, res) => {
       uid: userRecord.uid,
       email: userRecord.email,
       displayName: userRecord.displayName,
+      age,
       mentors,
     });
   } catch (err) {

--- a/src/controllers/mentorsController.js
+++ b/src/controllers/mentorsController.js
@@ -1,6 +1,17 @@
 const { firestore } = require('../config/firebase');
 const db = firestore;
 
+exports.createMentor = async (req, res) => {
+  const { name, email, phone } = req.body;
+  try {
+    const docRef = await db.collection('mentors').add({ name, email, phone });
+    res.status(201).json({ id: docRef.id, name, email, phone });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
 exports.assignMentor = async (req, res) => {
   const { mentorId, childId } = req.body;
   try {

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -1,4 +1,5 @@
-const { admin } = require('../config/firebase');
+const { admin, firestore } = require('../config/firebase');
+const db = firestore;
 
 exports.registerParent = async (req, res) => {
   const { email, password, name } = req.body;
@@ -25,11 +26,14 @@ exports.registerAdmin = async (req, res) => {
 };
 
 exports.addChild = async (req, res) => {
-  const { email, password, name } = req.body;
+  const { email, password, name, age } = req.body;
   const parentId = req.user.uid;
   try {
     const userRecord = await admin.auth().createUser({ email, password, displayName: name });
     await admin.auth().setCustomUserClaims(userRecord.uid, { role: 'child', parentId });
+    if (db) {
+      await db.collection('children').doc(userRecord.uid).set({ name, age, parentId });
+    }
     res.status(201).json({ uid: userRecord.uid, email: userRecord.email });
   } catch (err) {
     console.error(err);

--- a/src/routes/mentors.js
+++ b/src/routes/mentors.js
@@ -6,6 +6,7 @@ const recordsController = require('../controllers/mentorRecordsController');
 
 const router = express.Router();
 
+router.post('/create', auth, roleGuard(['admin']), controller.createMentor);
 router.post('/assign', auth, roleGuard(['parent']), controller.assignMentor);
 router.get('/:mentorId/children', auth, controller.getChildren);
 router.post('/records', auth, roleGuard(['mentor']), recordsController.createRecord);

--- a/test/childrenController.test.js
+++ b/test/childrenController.test.js
@@ -1,0 +1,49 @@
+const mockGetUser = jest.fn();
+const mockChildDocGet = jest.fn();
+const mockChildDoc = jest.fn(() => ({ get: mockChildDocGet }));
+const mockMentorGet = jest.fn().mockResolvedValue({ docs: [] });
+const mockMentorWhere = jest.fn(() => ({ get: mockMentorGet }));
+const mockCollection = jest.fn((name) => {
+  if (name === 'children') return { doc: mockChildDoc };
+  if (name === 'mentorAssignments') return { where: mockMentorWhere };
+  return {};
+});
+
+jest.mock('../src/config/firebase', () => ({
+  admin: { auth: () => ({ getUser: mockGetUser }) },
+  firestore: { collection: mockCollection },
+}));
+
+const childrenController = require('../src/controllers/childrenController');
+
+function mockResponse() {
+  const res = {};
+  res.json = jest.fn().mockReturnValue(res);
+  res.status = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('childrenController.getChildProfile', () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+    mockChildDocGet.mockReset();
+    mockChildDoc.mockClear();
+    mockMentorWhere.mockClear();
+    mockMentorGet.mockClear();
+    mockCollection.mockClear();
+  });
+
+  it('returns profile with age', async () => {
+    mockGetUser.mockResolvedValue({ uid: 'c1', email: 'c1@example.com', displayName: 'Kid' });
+    mockChildDocGet.mockResolvedValue({ exists: true, data: () => ({ age: 10 }) });
+    const req = { params: { childId: 'c1' } };
+    const res = mockResponse();
+
+    await childrenController.getChildProfile(req, res);
+
+    expect(mockCollection).toHaveBeenCalledWith('children');
+    expect(mockChildDoc).toHaveBeenCalledWith('c1');
+    expect(mockChildDocGet).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ uid: 'c1', email: 'c1@example.com', displayName: 'Kid', age: 10, mentors: [] });
+  });
+});

--- a/test/mentorsController.test.js
+++ b/test/mentorsController.test.js
@@ -1,0 +1,35 @@
+const mockAdd = jest.fn();
+const mockCollection = jest.fn(() => ({ add: mockAdd }));
+
+jest.mock('../src/config/firebase', () => ({
+  firestore: { collection: mockCollection },
+}));
+
+const mentorsController = require('../src/controllers/mentorsController');
+
+function mockResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('mentorsController.createMentor', () => {
+  beforeEach(() => {
+    mockAdd.mockReset();
+    mockCollection.mockClear();
+  });
+
+  it('creates mentor profile', async () => {
+    mockAdd.mockResolvedValue({ id: 'm1' });
+    const req = { body: { name: 'Mentor', email: 'm@example.com', phone: '123' } };
+    const res = mockResponse();
+
+    await mentorsController.createMentor(req, res);
+
+    expect(mockCollection).toHaveBeenCalledWith('mentors');
+    expect(mockAdd).toHaveBeenCalledWith({ name: 'Mentor', email: 'm@example.com', phone: '123' });
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ id: 'm1', name: 'Mentor', email: 'm@example.com', phone: '123' });
+  });
+});

--- a/test/usersController.test.js
+++ b/test/usersController.test.js
@@ -1,0 +1,48 @@
+const mockSet = jest.fn();
+const mockDoc = jest.fn(() => ({ set: mockSet }));
+const mockCollection = jest.fn(() => ({ doc: mockDoc }));
+
+const mockCreateUser = jest.fn().mockResolvedValue({ uid: 'c1', email: 'child@example.com' });
+const mockSetClaims = jest.fn().mockResolvedValue();
+
+jest.mock('../src/config/firebase', () => ({
+  firestore: { collection: mockCollection },
+  admin: { auth: () => ({ createUser: mockCreateUser, setCustomUserClaims: mockSetClaims }) },
+}));
+
+const usersController = require('../src/controllers/usersController');
+
+function mockResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('usersController.addChild', () => {
+  beforeEach(() => {
+    mockSet.mockReset();
+    mockDoc.mockClear();
+    mockCollection.mockClear();
+    mockCreateUser.mockClear();
+    mockSetClaims.mockClear();
+  });
+
+  it('creates child account and stores profile', async () => {
+    const req = {
+      body: { email: 'child@example.com', password: 'pass', name: 'Kid', age: 9 },
+      user: { uid: 'parent1' },
+    };
+    const res = mockResponse();
+
+    await usersController.addChild(req, res);
+
+    expect(mockCreateUser).toHaveBeenCalledWith({ email: 'child@example.com', password: 'pass', displayName: 'Kid' });
+    expect(mockSetClaims).toHaveBeenCalledWith('c1', { role: 'child', parentId: 'parent1' });
+    expect(mockCollection).toHaveBeenCalledWith('children');
+    expect(mockDoc).toHaveBeenCalledWith('c1');
+    expect(mockSet).toHaveBeenCalledWith({ name: 'Kid', age: 9, parentId: 'parent1' });
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ uid: 'c1', email: 'child@example.com' });
+  });
+});


### PR DESCRIPTION
## Summary
- track child name and age when parents add child accounts
- allow admins to create mentor profiles with name, email, and phone
- document new fields and endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892e0627df083279c086ccd74ea5e25