### PR TITLE
Add mentor and child listing endpoints

### DIFF
--- a/src/controllers/childrenController.js
+++ b/src/controllers/childrenController.js
@@ -28,3 +28,14 @@ exports.getChildProfile = async (req, res) => {
     res.status(400).json({ message: err.message });
   }
 };
+
+exports.listChildren = async (req, res) => {
+  try {
+    const snapshot = await db.collection('children').get();
+    const children = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    res.json(children);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/controllers/mentorsController.js
+++ b/src/controllers/mentorsController.js
@@ -12,6 +12,17 @@ exports.createMentor = async (req, res) => {
   }
 };
 
+exports.listMentors = async (req, res) => {
+  try {
+    const snapshot = await db.collection('mentors').get();
+    const mentors = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    res.json(mentors);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
 exports.assignMentor = async (req, res) => {
   const { mentorId, childId } = req.body;
   try {
@@ -31,7 +42,7 @@ exports.getChildren = async (req, res) => {
       .where('mentorId', '==', mentorId)
       .get();
     const children = snapshot.docs.map((d) => d.data().childId);
-    res.json(children);
+    res.json({ children });
   } catch (err) {
     console.error(err);
     res.status(400).json({ message: err.message });

--- a/src/routes/children.js
+++ b/src/routes/children.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const auth = require('../middlewares/authMiddleware');
 const childAccess = require('../middlewares/childAccess');
+const roleGuard = require('../middlewares/roleGuard');
 const controller = require('../controllers/childrenController');
 
 const router = express.Router();
 
+router.get('/', auth, roleGuard('admin'), controller.listChildren);
 router.get('/:childId', auth, childAccess, controller.getChildProfile);
 
 module.exports = router;

--- a/src/routes/mentors.js
+++ b/src/routes/mentors.js
@@ -7,6 +7,7 @@ const recordsController = require('../controllers/mentorRecordsController');
 const router = express.Router();
 
 router.post('/create', auth, roleGuard(['admin']), controller.createMentor);
+router.get('/', auth, roleGuard(['admin']), controller.listMentors);
 router.post('/assign', auth, roleGuard(['parent']), controller.assignMentor);
 router.get('/:mentorId/children', auth, controller.getChildren);
 router.post('/records', auth, roleGuard(['mentor']), recordsController.createRecord);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -26,10 +26,20 @@ describe('Auth middleware', () => {
     expect(res.statusCode).toEqual(401);
   });
 
+  it('should reject unauthorized children list request', async () => {
+    const res = await request(app).get('/api/children');
+    expect(res.statusCode).toEqual(401);
+  });
+
   it('should reject unauthorized mentor assignment', async () => {
     const res = await request(app)
       .post('/api/mentors/assign')
       .send({ childId: 'c1', mentorId: 'm1' });
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized mentors list request', async () => {
+    const res = await request(app).get('/api/mentors');
     expect(res.statusCode).toEqual(401);
   });
 

--- a/test/mentorsController.test.js
+++ b/test/mentorsController.test.js
@@ -1,5 +1,6 @@
 const mockAdd = jest.fn();
-const mockCollection = jest.fn(() => ({ add: mockAdd }));
+const mockGet = jest.fn();
+const mockCollection = jest.fn(() => ({ add: mockAdd, get: mockGet }));
 
 jest.mock('../src/config/firebase', () => ({
   firestore: { collection: mockCollection },
@@ -17,6 +18,7 @@ function mockResponse() {
 describe('mentorsController.createMentor', () => {
   beforeEach(() => {
     mockAdd.mockReset();
+    mockGet.mockReset();
     mockCollection.mockClear();
   });
 
@@ -31,5 +33,29 @@ describe('mentorsController.createMentor', () => {
     expect(mockAdd).toHaveBeenCalledWith({ name: 'Mentor', email: 'm@example.com', phone: '123' });
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith({ id: 'm1', name: 'Mentor', email: 'm@example.com', phone: '123' });
+  });
+});
+
+describe('mentorsController.listMentors', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockCollection.mockClear();
+  });
+
+  it('returns list of mentors', async () => {
+    mockGet.mockResolvedValue({
+      docs: [
+        { id: 'm1', data: () => ({ name: 'Mentor', email: 'm@example.com', phone: '123' }) },
+      ],
+    });
+    const req = {};
+    const res = mockResponse();
+
+    await mentorsController.listMentors(req, res);
+
+    expect(mockCollection).toHaveBeenCalledWith('mentors');
+    expect(res.json).toHaveBeenCalledWith([
+      { id: 'm1', name: 'Mentor', email: 'm@example.com', phone: '123' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- expose list of mentors via `/api/mentors` for admin assignment tools
- expose list of children via `/api/children` and include routing/role guards
- adjust mentor children response to wrap IDs in `children` array
- expand test coverage for new endpoints and unauthorized access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689373e3c24c83279a42ac82bc465483