### PR TITLE
Fix mentor record lookup

### DIFF
--- a/src/controllers/mentorRecordsController.js
+++ b/src/controllers/mentorRecordsController.js
@@ -21,11 +21,21 @@ exports.createRecord = async (req, res) => {
 };
 
 exports.getRecords = async (req, res) => {
-  const { childId } = req.params;
+  // A single endpoint is used by both parents and mentors to retrieve
+  // mentoring records.  Parents request records for their children while
+  // mentors request records that they have created.  Previously the handler
+  // only looked for a `childId` parameter which meant requests made by
+  // mentors (who supply their own user id) were not handled correctly by the
+  // backend, resulting in 404 errors in the client.
+  const { uid } = req.params; // uid can be either a childId or mentorId
   try {
+    // Determine which field to filter on based on the caller's role. Parents
+    // should receive records for their children, mentors should receive the
+    // records they authored.
+    const field = req.user && req.user.role === 'mentor' ? 'mentorId' : 'childId';
     const snapshot = await db
       .collection('mentorRecords')
-      .where('childId', '==', childId)
+      .where(field, '==', uid)
       .orderBy('created', 'desc')
       .get();
     const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));

--- a/src/routes/mentors.js
+++ b/src/routes/mentors.js
@@ -11,6 +11,9 @@ router.get('/', auth, roleGuard(['admin']), controller.listMentors);
 router.post('/assign', auth, roleGuard(['parent']), controller.assignMentor);
 router.get('/:mentorId/children', auth, controller.getChildren);
 router.post('/records', auth, roleGuard(['mentor']), recordsController.createRecord);
-router.get('/:childId/records', auth, roleGuard(['parent', 'mentor']), recordsController.getRecords);
+// Retrieve mentor records for either a child (parent view) or a mentor (their
+// own records).  The controller inspects the authenticated user's role to
+// decide whether to filter on `childId` or `mentorId`.
+router.get('/:uid/records', auth, roleGuard(['parent', 'mentor']), recordsController.getRecords);
 
 module.exports = router;

--- a/test/mentorRecordsController.test.js
+++ b/test/mentorRecordsController.test.js
@@ -1,0 +1,51 @@
+const mockGet = jest.fn();
+const mockOrderBy = jest.fn(() => ({ get: mockGet }));
+const mockWhere = jest.fn(() => ({ orderBy: mockOrderBy }));
+const mockCollection = jest.fn(() => ({ where: mockWhere }));
+
+jest.mock('../src/config/firebase', () => ({
+  firestore: { collection: mockCollection },
+  admin: { firestore: { FieldValue: { serverTimestamp: jest.fn() } } }
+}));
+
+const controller = require('../src/controllers/mentorRecordsController');
+
+function mockResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('mentorRecordsController.getRecords', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockOrderBy.mockClear();
+    mockWhere.mockClear();
+    mockCollection.mockClear();
+  });
+
+  it('queries by childId for parents', async () => {
+    mockGet.mockResolvedValue({ docs: [] });
+    const req = { params: { uid: 'child1' }, user: { role: 'parent' } };
+    const res = mockResponse();
+
+    await controller.getRecords(req, res);
+
+    expect(mockCollection).toHaveBeenCalledWith('mentorRecords');
+    expect(mockWhere).toHaveBeenCalledWith('childId', '==', 'child1');
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+
+  it('queries by mentorId for mentors', async () => {
+    mockGet.mockResolvedValue({ docs: [] });
+    const req = { params: { uid: 'mentor1' }, user: { role: 'mentor' } };
+    const res = mockResponse();
+
+    await controller.getRecords(req, res);
+
+    expect(mockWhere).toHaveBeenCalledWith('mentorId', '==', 'mentor1');
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow mentors to fetch their own mentoring records using same endpoint as parents
- document route for role-aware record retrieval
- add tests for mentor record retrieval logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689401fe356c83279d9383d4186aa46d