### PR TITLE
feat: allow admins to grant admin role

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npm test
 
 - `POST /api/users/register-parent` – Create a parent account.
 - `POST /api/users/register-admin` – Create an admin account.
+- `POST /api/users/set-admin` – Grant admin role to a user (admin only).
 - `POST /api/users/add-child` – Add a child account with name and age (parent only).
 - `GET  /api/users/me` – Retrieve the current user's profile.
 - `POST /api/checkins` – Submit a check-in entry.

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -25,6 +25,20 @@ exports.registerAdmin = async (req, res) => {
   }
 };
 
+exports.setAdminRole = async (req, res) => {
+  const { uid } = req.body;
+  if (!uid) {
+    return res.status(400).json({ message: 'uid is required' });
+  }
+  try {
+    await admin.auth().setCustomUserClaims(uid, { role: 'admin' });
+    res.json({ uid, role: 'admin' });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
 exports.addChild = async (req, res) => {
   const { email, password, name, age } = req.body;
   const parentId = req.user.uid;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -9,5 +9,6 @@ router.post('/register-parent', usersController.registerParent);
 router.post('/register-admin', usersController.registerAdmin);
 router.post('/add-child', auth, roleGuard(['parent']), usersController.addChild);
 router.get('/me', auth, usersController.getMe);
+router.post('/set-admin', auth, roleGuard(['admin']), usersController.setAdminRole);
 
 module.exports = router;

--- a/test/usersController.test.js
+++ b/test/usersController.test.js
@@ -46,3 +46,19 @@ describe('usersController.addChild', () => {
     expect(res.json).toHaveBeenCalledWith({ uid: 'c1', email: 'child@example.com' });
   });
 });
+
+describe('usersController.setAdminRole', () => {
+  beforeEach(() => {
+    mockSetClaims.mockClear();
+  });
+
+  it('sets admin role for given uid', async () => {
+    const req = { body: { uid: 'admin1' } };
+    const res = mockResponse();
+
+    await usersController.setAdminRole(req, res);
+
+    expect(mockSetClaims).toHaveBeenCalledWith('admin1', { role: 'admin' });
+    expect(res.json).toHaveBeenCalledWith({ uid: 'admin1', role: 'admin' });
+  });
+});


### PR DESCRIPTION
## Summary
- add controller method to assign `admin` role via Firebase custom claims
- expose `/api/users/set-admin` endpoint secured for existing admins
- document new route and test admin role assignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689424df026483279a1a3cb6c183dc23