### PR TITLE
Support legacy /api/child endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ app.use('/api/checkins', checkinsRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/mental-status', mentalRoutes);
 app.use('/api/children', childrenRoutes);
+// Support legacy singular `/api/child` paths used by older clients
+app.use('/api/child', childrenRoutes);
 app.use('/api/mentors', mentorsRoutes);
 // Support legacy singular `/api/mentor` paths used by older clients
 app.use('/api/mentor', mentorsRoutes);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -31,6 +31,11 @@ describe('Auth middleware', () => {
     expect(res.statusCode).toEqual(401);
   });
 
+  it('should reject unauthorized legacy children list request', async () => {
+    const res = await request(app).get('/api/child');
+    expect(res.statusCode).toEqual(401);
+  });
+
   it('should reject unauthorized mentor assignment', async () => {
     const res = await request(app)
       .post('/api/mentors/assign')
@@ -40,6 +45,11 @@ describe('Auth middleware', () => {
 
   it('should reject unauthorized mentors list request', async () => {
     const res = await request(app).get('/api/mentors');
+    expect(res.statusCode).toEqual(401);
+  });
+
+  it('should reject unauthorized legacy mentors list request', async () => {
+    const res = await request(app).get('/api/mentor');
     expect(res.statusCode).toEqual(401);
   });
 


### PR DESCRIPTION
## Summary
- expose `/api/child` as an alias of `/api/children`
- add tests covering `/api/child` and existing `/api/mentor` aliases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689430bec9208327a8ca07e0908f29bd