### PR TITLE
Handle CORS preflight requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,23 @@ const pointsRoutes = require('./routes/points');
 const groupsRoutes = require('./routes/groups');
 
 const app = express();
-app.use(cors());
+
+// Configure CORS to allow requests from the production frontend and handle
+// preflight requests.  This ensures the `Access-Control-Allow-Origin` header
+// is present on all responses.
+const allowedOrigins = [
+  'https://kidsfaithtracker.netlify.app',
+  'http://localhost:3000', // local development
+];
+const corsOptions = {
+  origin: allowedOrigins,
+  optionsSuccessStatus: 200,
+};
+
+app.use(cors(corsOptions));
+// Explicitly handle preflight requests for all routes
+app.options('*', cors(corsOptions));
+
 app.use(express.json());
 app.use('/api/checkins', checkinsRoutes);
 app.use('/api/users', usersRoutes);


### PR DESCRIPTION
## Summary
- configure CORS to allow frontend domain and local dev
- explicitly handle OPTIONS requests for preflight

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68944025590c832780ca704e57bac423