### PR TITLE
Document mentor creation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm test
 - `POST /api/mental-status` – Submit a mental status entry.
 - `GET  /api/mental-status/:childId` – Get mental status logs for a child.
 - `GET  /api/children/:childId` – Get a child's profile, age and mentors.
-- `POST /api/mentors/create` – Add a mentor profile (admin only).
+- `POST /api/mentors` – Add a mentor profile (admin only). Legacy support: `POST /api/mentors/create`.
 - `POST /api/mentors/assign` – Assign a mentor to a child (parent only).
 - `GET  /api/mentors/:mentorId/children` – List children assigned to a mentor.
 - `POST /api/mentors/records` – Create a mentor progress note.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -237,10 +237,36 @@ paths:
       responses:
         '200':
           description: Array of entries
-  /api/mentors/create:
+  /api/mentors:
     post:
       summary: Create mentor profile
-      description: Admin role required.
+      description: Admin role required. Legacy path `/api/mentors/create` is also supported.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+              required:
+                - name
+                - email
+                - phone
+      responses:
+        '201':
+          description: Mentor created
+  /api/mentors/create:
+    post:
+      summary: Create mentor profile (legacy)
+      description: Admin role required. Prefer POST `/api/mentors`.
       security:
         - bearerAuth: []
       requestBody:


### PR DESCRIPTION
## Summary
- clarify mentor creation in README and OpenAPI spec by making POST `/api/mentors` the primary endpoint
- adjust groups controller tests to provide user info and updated expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68958392b9248327aac25848657edeea