### PR TITLE
fix: ensure CORS headers for allowed origins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,14 +20,21 @@ const parentChildRoutes = require('./routes/parentChild');
 const app = express();
 
 // Configure CORS to allow requests from the production frontend and handle
-// preflight requests.  This ensures the `Access-Control-Allow-Origin` header
-// is present on all responses.
+// preflight requests so that browsers see the required
+// `Access-Control-Allow-Origin` header on every response.
 const allowedOrigins = [
   'https://kidsfaithtracker.netlify.app',
   'http://localhost:3000', // local development
 ];
 const corsOptions = {
-  origin: allowedOrigins,
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+    return callback(new Error('Not allowed by CORS'), false);
+  },
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
   optionsSuccessStatus: 200,
 };
 

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -1,0 +1,13 @@
+const request = require('supertest');
+const app = require('../src/index');
+
+describe('CORS configuration', () => {
+  it('returns allowed origin header for preflight requests', async () => {
+    const res = await request(app)
+      .options('/api/mentors')
+      .set('Origin', 'https://kidsfaithtracker.netlify.app')
+      .set('Access-Control-Request-Method', 'GET');
+    expect(res.status).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe('https://kidsfaithtracker.netlify.app');
+  });
+});


### PR DESCRIPTION
## Summary
- validate request origins against allowed list and send CORS headers
- test CORS preflight with supertest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895962133248327a23ab6c31ad6ff3a