### PR TITLE
test: add coverage for mentor creation route

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -48,6 +48,13 @@ describe('Auth middleware', () => {
     expect(res.statusCode).toEqual(401);
   });
 
+  it('should reject unauthorized mentor creation', async () => {
+    const res = await request(app)
+      .post('/api/mentors')
+      .send({ name: 'Test Mentor', email: 'm@example.com', phone: '123' });
+    expect(res.statusCode).toEqual(401);
+  });
+
   it('should reject unauthorized legacy mentors list request', async () => {
     const res = await request(app).get('/api/mentor');
     expect(res.statusCode).toEqual(401);


### PR DESCRIPTION
## Summary
- add regression test to ensure POST /api/mentors exists and enforces auth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68958b3fd4688327b12600f9bbb017c3