### PR TITLE
Remove legacy singular routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,10 +49,9 @@ app.use(express.json());
 app.use('/api/checkins', checkinsRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/mental-status', mentalRoutes);
+// Primary routes
 app.use('/api/children', childrenRoutes);
-app.use('/api/child', childrenRoutes);
 app.use('/api/mentors', mentorsRoutes);
-app.use('/api/mentor', mentorsRoutes);
 app.use('/api/quizzes', quizzesRoutes);
 app.use('/api/bible-questions', bibleQuestionsRoutes);
 app.use('/api/essays', essaysRoutes);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -31,11 +31,6 @@ describe('Auth middleware', () => {
     expect(res.statusCode).toEqual(401);
   });
 
-  it('should reject unauthorized legacy children list request', async () => {
-    const res = await request(app).get('/api/child');
-    expect(res.statusCode).toEqual(401);
-  });
-
   it('should reject unauthorized mentor assignment', async () => {
     const res = await request(app)
       .post('/api/mentors/assign')
@@ -52,11 +47,6 @@ describe('Auth middleware', () => {
     const res = await request(app)
       .post('/api/mentors')
       .send({ name: 'Test Mentor', email: 'm@example.com', phone: '123' });
-    expect(res.statusCode).toEqual(401);
-  });
-
-  it('should reject unauthorized legacy mentors list request', async () => {
-    const res = await request(app).get('/api/mentor');
     expect(res.statusCode).toEqual(401);
   });
 


### PR DESCRIPTION
## Summary
- drop legacy /api/child and /api/mentor routes so plural endpoints are used
- update tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689606dff6fc8327bd31a924a15a597c