### PR TITLE
Create server-side child account service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm test
 - `POST /api/users/register-parent` – Create a parent account.
 - `POST /api/users/register-admin` – Create an admin account.
 - `POST /api/users/set-admin` – Grant admin role to a user (admin only).
-- `POST /api/users/add-child` – Add a child account with name and age (parent only).
+- `POST /api/users/add-child` – Add a child account with name and age (parent only). Uses the Firebase Admin SDK so the parent remains signed in while the server writes the child profile.
 - `GET  /api/users/me` – Retrieve the current user's profile.
 - `POST /api/checkins` – Submit a check-in entry.
 - `GET  /api/checkins/:childId` – Get check-ins for a specific child.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -20,7 +20,7 @@ paths:
   /api/users/add-child:
     post:
       summary: Add a child account
-      description: Parent role required.
+      description: "Parent role required. Creates the child using the Firebase Admin SDK so the parent remains signed in and the Firestore write occurs in a privileged environment."
       security:
         - bearerAuth: []
       requestBody:

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -1,5 +1,5 @@
-const { admin, firestore } = require('../config/firebase');
-const db = firestore;
+const { admin } = require('../config/firebase');
+const { createChildAccount } = require('../services/childAccountService');
 
 exports.registerParent = async (req, res) => {
   const { email, password, name } = req.body;
@@ -43,11 +43,13 @@ exports.addChild = async (req, res) => {
   const { email, password, name, age } = req.body;
   const parentId = req.user.uid;
   try {
-    const userRecord = await admin.auth().createUser({ email, password, displayName: name });
-    await admin.auth().setCustomUserClaims(userRecord.uid, { role: 'child', parentId });
-    if (db) {
-      await db.collection('children').doc(userRecord.uid).set({ name, age, parentId });
-    }
+    const userRecord = await createChildAccount({
+      email,
+      password,
+      name,
+      age,
+      parentId,
+    });
     res.status(201).json({ uid: userRecord.uid, email: userRecord.email });
   } catch (err) {
     console.error(err);

--- a/src/services/childAccountService.js
+++ b/src/services/childAccountService.js
@@ -1,0 +1,32 @@
+const { admin, firestore } = require('../config/firebase');
+const db = firestore;
+
+/**
+ * Creates a child account using Firebase Admin SDK and stores profile data.
+ * This should be called from a privileged environment so that the parent
+ * remains signed in on the client.
+ * @param {Object} params
+ * @param {string} params.email - Child's email
+ * @param {string} params.password - Child's password
+ * @param {string} params.name - Child's display name
+ * @param {number} params.age - Child's age
+ * @param {string} params.parentId - UID of the parent creating the child
+ * @returns {Promise<admin.auth.UserRecord>} The created Firebase user record
+ */
+async function createChildAccount({ email, password, name, age, parentId }) {
+  const userRecord = await admin.auth().createUser({
+    email,
+    password,
+    displayName: name,
+  });
+  await admin.auth().setCustomUserClaims(userRecord.uid, {
+    role: 'child',
+    parentId,
+  });
+  if (db) {
+    await db.collection('children').doc(userRecord.uid).set({ name, age, parentId });
+  }
+  return userRecord;
+}
+
+module.exports = { createChildAccount };

--- a/test/childAccountService.test.js
+++ b/test/childAccountService.test.js
@@ -1,0 +1,42 @@
+const mockSet = jest.fn();
+const mockDoc = jest.fn(() => ({ set: mockSet }));
+const mockCollection = jest.fn(() => ({ doc: mockDoc }));
+
+const mockCreateUser = jest.fn().mockResolvedValue({ uid: 'child1', email: 'child@example.com' });
+const mockSetClaims = jest.fn().mockResolvedValue();
+
+jest.mock('../src/config/firebase', () => ({
+  firestore: { collection: mockCollection },
+  admin: { auth: () => ({ createUser: mockCreateUser, setCustomUserClaims: mockSetClaims }) },
+}));
+
+const { createChildAccount } = require('../src/services/childAccountService');
+
+describe('createChildAccount', () => {
+  beforeEach(() => {
+    mockSet.mockReset();
+    mockDoc.mockClear();
+    mockCollection.mockClear();
+    mockCreateUser.mockClear();
+    mockSetClaims.mockClear();
+  });
+
+  it('uses admin SDK to create user, set claims, and store profile', async () => {
+    const params = {
+      email: 'child@example.com',
+      password: 'pass',
+      name: 'Kid',
+      age: 9,
+      parentId: 'parent1',
+    };
+
+    const user = await createChildAccount(params);
+
+    expect(mockCreateUser).toHaveBeenCalledWith({ email: 'child@example.com', password: 'pass', displayName: 'Kid' });
+    expect(mockSetClaims).toHaveBeenCalledWith('child1', { role: 'child', parentId: 'parent1' });
+    expect(mockCollection).toHaveBeenCalledWith('children');
+    expect(mockDoc).toHaveBeenCalledWith('child1');
+    expect(mockSet).toHaveBeenCalledWith({ name: 'Kid', age: 9, parentId: 'parent1' });
+    expect(user.uid).toBe('child1');
+  });
+});


### PR DESCRIPTION
## Summary
- extract child account creation into `childAccountService` using Firebase Admin SDK
- use service in `addChild` controller so parent stays signed in while server writes Firestore data
- document server-side child creation in README and API spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896fc914e308327878e02f3216a812c