### PR TITLE
Allow admins to view mentor records

### DIFF
--- a/src/controllers/mentorRecordsController.js
+++ b/src/controllers/mentorRecordsController.js
@@ -30,9 +30,10 @@ exports.getRecords = async (req, res) => {
   const { uid } = req.params; // uid can be either a childId or mentorId
   try {
     // Determine which field to filter on based on the caller's role. Parents
-    // should receive records for their children, mentors should receive the
-    // records they authored.
-    const field = req.user && req.user.role === 'mentor' ? 'mentorId' : 'childId';
+    // should receive records for their children, mentors (and admins viewing
+    // mentor records) should receive the records they authored.
+    const role = req.user && req.user.role;
+    const field = role === 'mentor' || role === 'admin' ? 'mentorId' : 'childId';
     const snapshot = await db
       .collection('mentorRecords')
       .where(field, '==', uid)

--- a/src/routes/mentors.js
+++ b/src/routes/mentors.js
@@ -16,7 +16,7 @@ router.use(auth);
 const adminOnly = roleGuard(['admin']);
 const parentOnly = roleGuard(['parent']);
 const mentorOnly = roleGuard(['mentor']);
-const parentOrMentor = roleGuard(['parent', 'mentor']);
+const parentMentorOrAdmin = roleGuard(['parent', 'mentor', 'admin']);
 
 // Mentor management (admin only)
 router
@@ -32,6 +32,6 @@ router.get('/:mentorId/children', controller.getChildren);
 
 // Mentor records
 router.post('/records', mentorOnly, recordsController.createRecord);
-router.get('/:uid/records', parentOrMentor, recordsController.getRecords);
+router.get('/:uid/records', parentMentorOrAdmin, recordsController.getRecords);
 
 module.exports = router;

--- a/test/mentorRecordsController.test.js
+++ b/test/mentorRecordsController.test.js
@@ -47,5 +47,16 @@ describe('mentorRecordsController.getRecords', () => {
     expect(mockWhere).toHaveBeenCalledWith('mentorId', '==', 'mentor1');
     expect(res.json).toHaveBeenCalledWith([]);
   });
+
+  it('queries by mentorId for admins', async () => {
+    mockGet.mockResolvedValue({ docs: [] });
+    const req = { params: { uid: 'mentor1' }, user: { role: 'admin' } };
+    const res = mockResponse();
+
+    await controller.getRecords(req, res);
+
+    expect(mockWhere).toHaveBeenCalledWith('mentorId', '==', 'mentor1');
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
 });
 


### PR DESCRIPTION
## Summary
- permit admin access to GET `/mentors/:uid/records`
- treat admins like mentors when querying mentor records
- test admin access for mentor record queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689757977000832787df97a213ff9081