### PR TITLE
feat: allow admins to assign user roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm test
 - `POST /api/users/register-parent` – Create a parent account.
 - `POST /api/users/register-admin` – Create an admin account.
 - `POST /api/users/set-admin` – Grant admin role to a user (admin only).
+- `POST /api/users/assign-role` – Assign mentor, child, or parent role to a user (admin only).
 - `POST /api/users/add-child` – Add a child account with name and age (parent only). Uses the Firebase Admin SDK so the parent remains signed in while the server writes the child profile.
 - `GET  /api/users/me` – Retrieve the current user's profile.
 - `POST /api/checkins` – Submit a check-in entry.

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -39,6 +39,24 @@ exports.setAdminRole = async (req, res) => {
   }
 };
 
+exports.assignRole = async (req, res) => {
+  const { uid, role } = req.body;
+  const allowed = ['mentor', 'child', 'parent'];
+  if (!uid || !role) {
+    return res.status(400).json({ message: 'uid and role are required' });
+  }
+  if (!allowed.includes(role)) {
+    return res.status(400).json({ message: 'Invalid role' });
+  }
+  try {
+    await admin.auth().setCustomUserClaims(uid, { role });
+    res.json({ uid, role });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
 exports.addChild = async (req, res) => {
   const { email, password, name, age } = req.body;
   const parentId = req.user.uid;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -10,5 +10,6 @@ router.post('/register-admin', usersController.registerAdmin);
 router.post('/add-child', auth, roleGuard(['parent']), usersController.addChild);
 router.get('/me', auth, usersController.getMe);
 router.post('/set-admin', auth, roleGuard(['admin']), usersController.setAdminRole);
+router.post('/assign-role', auth, roleGuard(['admin']), usersController.assignRole);
 
 module.exports = router;

--- a/test/usersController.test.js
+++ b/test/usersController.test.js
@@ -60,3 +60,19 @@ describe('usersController.setAdminRole', () => {
     expect(res.json).toHaveBeenCalledWith({ uid: 'admin1', role: 'admin' });
   });
 });
+
+describe('usersController.assignRole', () => {
+  beforeEach(() => {
+    mockSetClaims.mockClear();
+  });
+
+  it('assigns specified role to user', async () => {
+    const req = { body: { uid: 'user1', role: 'mentor' } };
+    const res = mockResponse();
+
+    await usersController.assignRole(req, res);
+
+    expect(mockSetClaims).toHaveBeenCalledWith('user1', { role: 'mentor' });
+    expect(res.json).toHaveBeenCalledWith({ uid: 'user1', role: 'mentor' });
+  });
+});


### PR DESCRIPTION
## Summary
- allow admins to assign mentor, child, or parent roles to users
- expose POST /api/users/assign-role route and document it
- add tests for assigning roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897f45f91188327a7f84baaaa1ea569