### PR TITLE
Add admin user listing route

### DIFF
--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -57,6 +57,22 @@ exports.assignRole = async (req, res) => {
   }
 };
 
+exports.listUsers = async (req, res) => {
+  try {
+    const result = await admin.auth().listUsers();
+    const users = result.users.map((u) => ({
+      uid: u.uid,
+      email: u.email,
+      displayName: u.displayName,
+      role: u.customClaims?.role || null,
+    }));
+    res.json(users);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: err.message });
+  }
+};
+
 exports.addChild = async (req, res) => {
   const { email, password, name, age } = req.body;
   const parentId = req.user.uid;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -11,5 +11,6 @@ router.post('/add-child', auth, roleGuard(['parent']), usersController.addChild)
 router.get('/me', auth, usersController.getMe);
 router.post('/set-admin', auth, roleGuard(['admin']), usersController.setAdminRole);
 router.post('/assign-role', auth, roleGuard(['admin']), usersController.assignRole);
+router.get('/', auth, roleGuard(['admin']), usersController.listUsers);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- provide `GET /api/users` endpoint returning basic user details for admins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898061fef908327a5327a3bb9488325