### PR TITLE
feat: add NestJS backend skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/htdc
+
+# Stripe
+STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+
+# Firebase Admin
+# Use Application Default Credentials or provide a service account JSON
+# Option A: set GOOGLE_APPLICATION_CREDENTIALS to a JSON path
+# Option B: paste JSON into FIREBASE_SERVICE_ACCOUNT_JSON (escaped)
+GOOGLE_APPLICATION_CREDENTIALS=
+FIREBASE_SERVICE_ACCOUNT_JSON=
+FIREBASE_PROJECT_ID=
+
+# CORS (comma separated origins)
+ALLOWED_ORIGINS=http://localhost:4200,https://yourwebapp.example
+
+# App
+PORT=4000
+NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# GFHarvestBackend
+# High‑Ticket Deal Closer API (NestJS)
+
+This repository contains a minimal backend API for managing leads, deals, proposals and payments.
+It is built with **NestJS**, **Prisma** (PostgreSQL), **Stripe** and **Firebase Admin**.
+
+## Features
+- Firebase authentication guard.
+- CRUD endpoints for leads and deals.
+- Proposal creation and stubbed send action.
+- Stripe checkout sessions and webhook handler.
+- Prisma schema for multi‑tenant CRM domain.
+
+## Requirements
+- Node.js 18+
+- PostgreSQL database (or use `docker-compose.yml`).
+
+## Setup
+```bash
+npm install
+cp .env.example .env   # fill in environment variables
+npx prisma migrate dev --name init
+npm run dev
+```
+
+The API will be available at `http://localhost:4000/v1` by default.
+
+## Scripts
+- `npm run dev` – start development server with `ts-node-dev`.
+- `npm run build` – compile TypeScript.
+- `npm run prisma:generate` – generate Prisma client.
+- `npm run prisma:migrate` – run database migrations.
+
+## Notes
+This is an MVP. Proposal sending is a stub and should be replaced with an actual DocuSign (or similar) integration. Add rate limiting, logging and proper multi‑tenant handling before production use.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: htdc
+    ports:
+      - '5432:5432'
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+volumes:
+  dbdata: {}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "htdc-api",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/main.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/main.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
+  },
+  "dependencies": {
+    "@fastify/cors": "^10.0.0",
+    "@fastify/helmet": "^12.0.0",
+    "@fastify/multipart": "^8.3.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.2.2",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@prisma/client": "^5.16.2",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
+    "firebase-admin": "^12.5.0",
+    "prisma": "^5.16.2",
+    "stripe": "^16.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.13",
+    "@types/stripe": "^10.14.0",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,173 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum RoleType {
+  OWNER
+  ADMIN
+  SELLER
+  VIEWER
+}
+
+enum Plan {
+  STARTER
+  PRO
+  ENTERPRISE
+}
+
+enum LeadStage {
+  NEW
+  QUALIFIED
+  DISCOVERY
+  PROPOSAL
+  WON
+  LOST
+}
+
+enum DealStage {
+  DISCOVERY
+  PROPOSAL
+  SENT
+  NEGOTIATION
+  WON
+  LOST
+}
+
+enum ProposalStatus {
+  DRAFT
+  SENT
+  VIEWED
+  SIGNED
+  DECLINED
+}
+
+enum SenderType {
+  USER
+  PROSPECT
+  SYSTEM
+}
+
+enum PaymentStatus {
+  PENDING
+  REQUIRES_ACTION
+  SUCCEEDED
+  CANCELED
+}
+
+model Account {
+  id        String        @id @default(cuid())
+  name      String
+  plan      Plan          @default(STARTER)
+  users     UserAccount[]
+  leads     Lead[]
+  deals     Deal[]
+  proposals Proposal[]
+  payments  Payment[]
+  createdAt DateTime      @default(now())
+}
+
+model User {
+  id        String        @id @default(cuid())
+  email     String        @unique
+  name      String?
+  avatarUrl String?
+  accounts  UserAccount[]
+  createdAt DateTime      @default(now())
+}
+
+model UserAccount {
+  userId    String
+  accountId String
+  role      RoleType      @default(OWNER)
+  user      User          @relation(fields: [userId], references: [id])
+  account   Account       @relation(fields: [accountId], references: [id])
+  @@id([userId, accountId])
+}
+
+model Lead {
+  id        String     @id @default(cuid())
+  accountId String
+  firstName String
+  lastName  String?
+  email     String?
+  phone     String?
+  company   String?
+  source    String?
+  stage     LeadStage  @default(NEW)
+  score     Int        @default(0)
+  tags      String[]
+  notes     String?
+  ownerId   String?
+  account   Account    @relation(fields: [accountId], references: [id])
+  deals     Deal[]
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+}
+
+model Deal {
+  id        String     @id @default(cuid())
+  accountId String
+  name      String
+  amount    Int
+  currency  String     @default("USD")
+  stage     DealStage  @default(DISCOVERY)
+  leadId    String?
+  ownerId   String?
+  proposal  Proposal?
+  account   Account    @relation(fields: [accountId], references: [id])
+  lead      Lead?      @relation(fields: [leadId], references: [id])
+  payments  Payment[]
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+}
+
+model Proposal {
+  id              String          @id @default(cuid())
+  accountId       String
+  dealId          String?
+  title           String
+  status          ProposalStatus  @default(DRAFT)
+  docUrl          String?
+  signEnvelopeId  String?
+  sentAt          DateTime?
+  viewedAt        DateTime?
+  signedAt        DateTime?
+  account         Account         @relation(fields: [accountId], references: [id])
+  deal            Deal?           @relation(fields: [dealId], references: [id])
+}
+
+model Payment {
+  id                     String         @id @default(cuid())
+  accountId              String
+  dealId                 String
+  stripePaymentIntentId  String
+  amount                 Int
+  currency               String        @default("USD")
+  status                 PaymentStatus @default(PENDING)
+  createdAt              DateTime      @default(now())
+  account                Account       @relation(fields: [accountId], references: [id])
+  deal                   Deal          @relation(fields: [dealId], references: [id])
+}
+
+model Activity {
+  id        String   @id @default(cuid())
+  accountId String?
+  actorId   String?
+  type      String
+  targetId  String?
+  meta      Json
+  createdAt DateTime @default(now())
+}
+
+model WebhookEvent {
+  id         String   @id @default(cuid())
+  provider   String
+  raw        Json
+  processed  Boolean  @default(false)
+  receivedAt DateTime @default(now())
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { PrismaService } from './common/prisma.service.js';
+import { AuthModule } from './auth/auth.module.js';
+import { LeadsModule } from './leads/leads.module.js';
+import { DealsModule } from './deals/deals.module.js';
+import { ProposalsModule } from './proposals/proposals.module.js';
+import { PaymentsModule } from './payments/payments.module.js';
+import { WebhooksModule } from './webhooks/webhooks.module.js';
+
+@Module({
+  imports: [ConfigModule.forRoot({ isGlobal: true }), AuthModule, LeadsModule, DealsModule, ProposalsModule, PaymentsModule, WebhooksModule],
+  providers: [PrismaService],
+})
+export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { FirebaseService } from './firebase.service.js';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private fb: FirebaseService) {}
+
+  @Post('verify')
+  async verify(@Body('idToken') idToken: string){
+    const decoded = await this.fb.auth().verifyIdToken(idToken);
+    return { uid: decoded.uid, email: decoded.email, claims: decoded }; // echo core claims
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { FirebaseService } from './firebase.service.js';
+import { AuthController } from './auth.controller.js';
+
+@Module({
+  providers: [FirebaseService],
+  controllers: [AuthController],
+  exports: [FirebaseService],
+})
+export class AuthModule {}

--- a/src/auth/firebase-auth.guard.ts
+++ b/src/auth/firebase-auth.guard.ts
@@ -1,0 +1,20 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { FirebaseService } from './firebase.service.js';
+
+@Injectable()
+export class FirebaseAuthGuard implements CanActivate {
+  constructor(private fb: FirebaseService) {}
+  async canActivate(ctx: ExecutionContext): Promise<boolean> {
+    const req = ctx.switchToHttp().getRequest();
+    const authHeader = req.headers['authorization'] || '';
+    if (!authHeader.startsWith('Bearer ')) throw new UnauthorizedException('Missing bearer token');
+    const idToken = authHeader.substring('Bearer '.length);
+    try {
+      const decoded = await this.fb.auth().verifyIdToken(idToken);
+      req.user = decoded; // uid, email, etc.
+      return true;
+    } catch (e) {
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
+}

--- a/src/auth/firebase.service.ts
+++ b/src/auth/firebase.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import * as admin from 'firebase-admin';
+
+@Injectable()
+export class FirebaseService {
+  private app: admin.app.App;
+  constructor(){
+    if (!admin.apps.length) {
+      if (process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+        const svc = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+        this.app = admin.initializeApp({ credential: admin.credential.cert(svc) });
+      } else {
+        this.app = admin.initializeApp({ credential: admin.credential.applicationDefault() });
+      }
+    } else {
+      this.app = admin.app();
+    }
+  }
+
+  auth(){ return this.app.auth(); }
+}

--- a/src/common/prisma.service.ts
+++ b/src/common/prisma.service.ts
@@ -1,0 +1,10 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() { await this.$connect(); }
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => { await app.close(); });
+  }
+}

--- a/src/deals/deals.controller.ts
+++ b/src/deals/deals.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { DealsService } from './deals.service.js';
+import { FirebaseAuthGuard } from '../auth/firebase-auth.guard.js';
+import { CreateDealDto, UpdateDealDto } from './dto.js';
+
+@Controller('deals')
+@UseGuards(FirebaseAuthGuard)
+export class DealsController {
+  constructor(private svc: DealsService) {}
+  private accountId(req: any){ return req.headers['x-account-id'] || 'demo'; }
+  private ownerId(req: any){ return req.user?.uid as string | undefined; }
+
+  @Get() list(@Req() req: any){ return this.svc.list(this.accountId(req)); }
+  @Get(':id') get(@Req() req: any, @Param('id') id: string){ return this.svc.get(this.accountId(req), id); }
+  @Post() create(@Req() req: any, @Body() dto: CreateDealDto){ return this.svc.create(this.accountId(req), this.ownerId(req), dto); }
+  @Patch(':id') update(@Req() req: any, @Param('id') id: string, @Body() dto: UpdateDealDto){ return this.svc.update(this.accountId(req), id, dto); }
+}

--- a/src/deals/deals.module.ts
+++ b/src/deals/deals.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { DealsController } from './deals.controller.js';
+import { DealsService } from './deals.service.js';
+import { FirebaseService } from '../auth/firebase.service.js';
+
+@Module({ controllers: [DealsController], providers: [DealsService, FirebaseService] })
+export class DealsModule {}

--- a/src/deals/deals.service.ts
+++ b/src/deals/deals.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service.js';
+import { CreateDealDto, UpdateDealDto } from './dto.js';
+
+@Injectable()
+export class DealsService {
+  constructor(private prisma: PrismaService) {}
+
+  list(accountId: string){ return this.prisma.deal.findMany({ where: { accountId }, orderBy: { createdAt: 'desc' } }); }
+  get(accountId: string, id: string){ return this.prisma.deal.findFirst({ where: { id, accountId } }); }
+
+  create(accountId: string, ownerId: string | undefined, dto: CreateDealDto){
+    return this.prisma.deal.create({ data: { accountId, ownerId, stage: 'DISCOVERY', ...dto } });
+  }
+
+  update(accountId: string, id: string, dto: UpdateDealDto){ return this.prisma.deal.update({ where: { id }, data: dto }); }
+}

--- a/src/deals/dto.ts
+++ b/src/deals/dto.ts
@@ -1,0 +1,14 @@
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class CreateDealDto {
+  @IsString() name!: string;
+  @IsInt() @Min(0) amount!: number;
+  @IsOptional() @IsString() leadId?: string;
+  @IsOptional() @IsString() currency?: string;
+}
+
+export class UpdateDealDto {
+  @IsOptional() @IsString() name?: string;
+  @IsOptional() @IsInt() @Min(0) amount?: number;
+  @IsOptional() @IsString() stage?: string;
+}

--- a/src/leads/dto.ts
+++ b/src/leads/dto.ts
@@ -1,0 +1,22 @@
+import { IsEmail, IsOptional, IsString } from 'class-validator';
+
+export class CreateLeadDto {
+  @IsString() firstName!: string;
+  @IsOptional() @IsString() lastName?: string;
+  @IsOptional() @IsEmail() email?: string;
+  @IsOptional() @IsString() phone?: string;
+  @IsOptional() @IsString() company?: string;
+  @IsOptional() @IsString() source?: string;
+}
+
+export class UpdateLeadDto {
+  @IsOptional() @IsString() firstName?: string;
+  @IsOptional() @IsString() lastName?: string;
+  @IsOptional() @IsEmail() email?: string;
+  @IsOptional() @IsString() phone?: string;
+  @IsOptional() @IsString() company?: string;
+  @IsOptional() @IsString() source?: string;
+  @IsOptional() @IsString() stage?: string;
+  @IsOptional() score?: number;
+  @IsOptional() @IsString() notes?: string;
+}

--- a/src/leads/leads.controller.ts
+++ b/src/leads/leads.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { FirebaseAuthGuard } from '../auth/firebase-auth.guard.js';
+import { LeadsService } from './leads.service.js';
+import { CreateLeadDto, UpdateLeadDto } from './dto.js';
+
+@Controller('leads')
+@UseGuards(FirebaseAuthGuard)
+export class LeadsController {
+  constructor(private svc: LeadsService) {}
+
+  private accountId(req: any){ return req.headers['x-account-id'] || 'demo'; }
+  private ownerId(req: any){ return req.user?.uid as string | undefined; }
+
+  @Get()
+  list(@Req() req: any){ return this.svc.list(this.accountId(req)); }
+
+  @Get(':id')
+  get(@Req() req: any, @Param('id') id: string){ return this.svc.get(this.accountId(req), id); }
+
+  @Post()
+  create(@Req() req: any, @Body() dto: CreateLeadDto){ return this.svc.create(this.accountId(req), this.ownerId(req), dto); }
+
+  @Patch(':id')
+  update(@Req() req: any, @Param('id') id: string, @Body() dto: UpdateLeadDto){ return this.svc.update(this.accountId(req), id, dto); }
+}

--- a/src/leads/leads.module.ts
+++ b/src/leads/leads.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { LeadsController } from './leads.controller.js';
+import { LeadsService } from './leads.service.js';
+import { FirebaseService } from '../auth/firebase.service.js';
+
+@Module({ controllers: [LeadsController], providers: [LeadsService, FirebaseService] })
+export class LeadsModule {}

--- a/src/leads/leads.service.ts
+++ b/src/leads/leads.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service.js';
+import { CreateLeadDto, UpdateLeadDto } from './dto.js';
+
+@Injectable()
+export class LeadsService {
+  constructor(private prisma: PrismaService) {}
+
+  list(accountId: string){
+    return this.prisma.lead.findMany({ where: { accountId }, orderBy: { createdAt: 'desc' } });
+  }
+
+  get(accountId: string, id: string){
+    return this.prisma.lead.findFirst({ where: { id, accountId } });
+  }
+
+  async create(accountId: string, ownerId: string | undefined, dto: CreateLeadDto){
+    return this.prisma.lead.create({ data: { accountId, ownerId, ...dto, tags: [] } });
+  }
+
+  async update(accountId: string, id: string, dto: UpdateLeadDto){
+    return this.prisma.lead.update({ where: { id }, data: dto });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,29 @@
+import 'dotenv/config';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module.js';
+import { ValidationPipe } from '@nestjs/common';
+import helmet from '@fastify/helmet';
+import cors from '@fastify/cors';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+
+  // Global prefix v1
+  app.setGlobalPrefix('v1');
+
+  // Validation
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+  // Register fastify plugins (using Express adapter under the hood is fine)
+  // If using Fastify adapter, adjust accordingly.
+  // CORS
+  const origins = (process.env.ALLOWED_ORIGINS || '').split(',').map(s => s.trim()).filter(Boolean);
+  app.enableCors({ origin: origins.length ? origins : true, credentials: true });
+
+  const port = process.env.PORT ? Number(process.env.PORT) : 4000;
+  await app.listen(port);
+  // eslint-disable-next-line no-console
+  console.log(`API running on http://localhost:${port}/v1`);
+}
+
+bootstrap();

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { StripeService } from './stripe.service.js';
+import { PrismaService } from '../common/prisma.service.js';
+import { FirebaseAuthGuard } from '../auth/firebase-auth.guard.js';
+import { IsInt, IsString, IsUrl, Min } from 'class-validator';
+
+class CheckoutDto {
+  @IsString() dealId!: string;
+  @IsInt() @Min(100) amount!: number; // cents
+  @IsUrl() successUrl!: string;
+  @IsUrl() cancelUrl!: string;
+}
+
+@Controller('payments')
+@UseGuards(FirebaseAuthGuard)
+export class PaymentsController {
+  constructor(private stripe: StripeService, private prisma: PrismaService) {}
+  private accountId(req: any){ return req.headers['x-account-id'] || 'demo'; }
+
+  @Post('checkout')
+  async checkout(@Req() req: any, @Body() dto: CheckoutDto){
+    const session = await this.stripe.createCheckout(dto.amount, dto.successUrl, dto.cancelUrl);
+    // Optionally create a pending Payment record
+    await this.prisma.payment.create({ data: { accountId: this.accountId(req), dealId: dto.dealId, stripePaymentIntentId: session.payment_intent as string, amount: dto.amount, status: 'PENDING' } });
+    return { id: session.id, url: session.url };
+  }
+}

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+import { PaymentsController } from './payments.controller.js';
+import { StripeService } from './stripe.service.js';
+
+@Module({ controllers: [PaymentsController], providers: [StripeService] })
+export class PaymentsModule {}

--- a/src/payments/stripe.service.ts
+++ b/src/payments/stripe.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import Stripe from 'stripe';
+
+@Injectable()
+export class StripeService {
+  private stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, { apiVersion: '2024-06-20' });
+
+  async createCheckout(amountCents: number, successUrl: string, cancelUrl: string){
+    const session = await this.stripe.checkout.sessions.create({
+      mode: 'payment',
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      line_items: [{ price_data: { currency: 'usd', product_data: { name: 'High‑Ticket Deposit' }, unit_amount: amountCents }, quantity: 1 }],
+    });
+    return session;
+  }
+}

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service.js';
+import { FirebaseAuthGuard } from '../auth/firebase-auth.guard.js';
+import { IsOptional, IsString, IsUrl } from 'class-validator';
+
+class CreateProposalDto {
+  @IsString() dealId!: string;
+  @IsString() title!: string;
+  @IsOptional() @IsUrl() docUrl?: string;
+}
+
+class SendProposalDto { @IsString() proposalId!: string; @IsString() recipientEmail!: string; }
+
+@Controller('proposals')
+@UseGuards(FirebaseAuthGuard)
+export class ProposalsController {
+  constructor(private prisma: PrismaService) {}
+  private accountId(req: any){ return req.headers['x-account-id'] || 'demo'; }
+
+  @Post()
+  async create(@Req() req: any, @Body() dto: CreateProposalDto){
+    return this.prisma.proposal.create({ data: { accountId: this.accountId(req), dealId: dto.dealId, title: dto.title, docUrl: dto.docUrl, status: 'DRAFT' } });
+  }
+
+  @Post('send')
+  async send(@Req() req: any, @Body() dto: SendProposalDto){
+    // TODO: integrate DocuSign. For now, mark as SENT and set sentAt.
+    const p = await this.prisma.proposal.update({ where: { id: dto.proposalId }, data: { status: 'SENT', sentAt: new Date() } });
+    // You can enqueue email send here.
+    return { ok: true, proposal: p };
+  }
+}

--- a/src/proposals/proposals.module.ts
+++ b/src/proposals/proposals.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+import { ProposalsController } from './proposals.controller.js';
+import { FirebaseService } from '../auth/firebase.service.js';
+
+@Module({ controllers: [ProposalsController], providers: [FirebaseService] })
+export class ProposalsModule {}

--- a/src/webhooks/stripe.webhook.controller.ts
+++ b/src/webhooks/stripe.webhook.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Headers, Post, Req } from '@nestjs/common';
+import Stripe from 'stripe';
+import { PrismaService } from '../common/prisma.service.js';
+
+@Controller('webhooks/stripe')
+export class StripeWebhookController {
+  private stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, { apiVersion: '2024-06-20' });
+
+  constructor(private prisma: PrismaService) {}
+
+  @Post()
+  async handle(@Req() req: any, @Body() body: any, @Headers('stripe-signature') sig: string){
+    const secret = process.env.STRIPE_WEBHOOK_SECRET as string;
+    let event: Stripe.Event;
+    try {
+      const buf = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(JSON.stringify(body));
+      event = this.stripe.webhooks.constructEvent(buf, sig!, secret);
+    } catch (err) {
+      return { error: 'Invalid signature' };
+    }
+
+    switch(event.type){
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const pi = session.payment_intent as string;
+        await this.prisma.payment.updateMany({ where: { stripePaymentIntentId: pi }, data: { status: 'SUCCEEDED' } });
+        break;
+      }
+    }
+    return { received: true };
+  }
+}

--- a/src/webhooks/webhooks.module.ts
+++ b/src/webhooks/webhooks.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { StripeWebhookController } from './stripe.webhook.controller.js';
+
+@Module({ controllers: [StripeWebhookController] })
+export class WebhooksModule {}

--- a/todos.md
+++ b/todos.md
@@ -1,0 +1,6 @@
+# TODOs
+
+- Integrate DocuSign for proposal sending and signatures.
+- Add rate limiting and logging middleware.
+- Implement proper account mapping instead of `X-Account-Id` header fallback.
+- Expand test coverage and add CI pipeline.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es2021",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- setup NestJS API with Prisma, Stripe, and Firebase modules
- add Prisma schema and env example for configuration
- document setup in README and track future work in todos

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@fastify%2fcors)*
- `npm run build` *(fails: Cannot find module '@nestjs/common' ...)*

------
https://chatgpt.com/codex/tasks/task_e_689bd4e5de348327ae86a42d43f154c1