### PR TITLE
chore: include node types and remove stripe type dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.13",
-    "@types/stripe": "^10.14.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "emitDecoratorMetadata": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "esModuleInterop": true
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## Summary
- include Node.js type declarations in TypeScript config
- remove obsolete @types/stripe dev dependency

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_689bf1745d188327b19cde90ca24317f