### PR TITLE
feat: expand church profiles and prayer requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ npm test
 - `POST /api/mentors/assign` – Assign a mentor to a child (parent only).
 - `POST /api/churches` – Register a church with its logo.
 - `GET  /api/churches` – List registered churches.
+- `GET  /api/churches/:id` – Retrieve a church profile.
+- `PATCH /api/churches/:id` – Update church name or logo.
 - `POST /api/prayer-requests` – Submit a prayer request with a user ID.
-- `GET  /api/prayer-requests` – List all prayer requests.
+- `GET  /api/prayer-requests` – List all prayer requests (filter by \`userId\` with query parameter).
+- `PATCH /api/prayer-requests/:id` – Update a prayer request's details.
 - `PATCH /api/prayer-requests/:id/prayed` – Mark a request as prayed for.
 - `GET  /api/mentors/:mentorId/children` – List children assigned to a mentor.
 - `POST /api/mentors/records` – Create a mentor progress note.
@@ -78,6 +81,10 @@ This project uses **Jest**. After installing dependencies run:
 ```bash
 npm test
 ```
+
+## Maintenance Scripts
+
+- `npm run prayer-cleanup` – Remove prayer requests that were marked as prayed more than 7 days ago.
 
 ## Roadmap
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "nodemon src/index.js",
     "test": "jest",
     "weekly-summary": "node src/jobs/weeklySummary.js",
-    "send-reminders": "node src/jobs/reminderJobs.js"
+    "send-reminders": "node src/jobs/reminderJobs.js",
+    "prayer-cleanup": "node src/jobs/prayerCleanup.js"
   },
   "repository": {
     "type": "git",

--- a/src/controllers/churchesController.js
+++ b/src/controllers/churchesController.js
@@ -29,3 +29,35 @@ exports.listChurches = async (req, res) => {
     res.status(400).json({ message: err.message });
   }
 };
+
+exports.getChurch = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const doc = await db.collection('churches').doc(id).get();
+    if (!doc.exists) {
+      return res.status(404).json({ message: 'Church not found' });
+    }
+    res.json({ id: doc.id, ...doc.data() });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.updateChurch = async (req, res) => {
+  const { id } = req.params;
+  const { name, logoUrl } = req.body;
+  if (!name && !logoUrl) {
+    return res.status(400).json({ message: 'name or logoUrl must be provided' });
+  }
+  const updates = {};
+  if (name) updates.name = name;
+  if (logoUrl) updates.logoUrl = logoUrl;
+  try {
+    await db.collection('churches').doc(id).update(updates);
+    res.json({ id, ...updates });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/controllers/prayerRequestsController.js
+++ b/src/controllers/prayerRequestsController.js
@@ -1,19 +1,40 @@
 const { firestore } = require('../config/firebase');
 const db = firestore;
 
+function computeAgeData(birthday) {
+  if (!birthday) return {};
+  const birthDate = new Date(birthday);
+  if (Number.isNaN(birthDate.getTime())) return {};
+  const today = new Date();
+  let age = today.getFullYear() - birthDate.getFullYear();
+  const m = today.getMonth() - birthDate.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+    age--;
+  }
+  const ageGroup = age >= 18 ? 'adult' : 'child';
+  const color = ageGroup === 'adult' ? 'purple' : 'blue';
+  return { age, ageGroup, color };
+}
+
 exports.addRequest = async (req, res) => {
-  const { userId, text } = req.body;
+  const { userId, text, birthday, timeZone, gender } = req.body;
   if (!userId || !text) {
     return res.status(400).json({ message: 'userId and text are required' });
   }
   try {
-    const docRef = await db.collection('prayerRequests').add({
+    const ageData = computeAgeData(birthday);
+    const docData = {
       userId,
       text,
+      birthday: birthday || null,
+      timeZone: timeZone || null,
+      gender: gender || null,
+      ...ageData,
       createdAt: new Date().toISOString(),
       prayedAt: null,
-    });
-    res.status(201).json({ id: docRef.id, userId, text });
+    };
+    const docRef = await db.collection('prayerRequests').add(docData);
+    res.status(201).json({ id: docRef.id, ...docData });
   } catch (err) {
     console.error(err);
     res.status(400).json({ message: err.message });
@@ -22,9 +43,38 @@ exports.addRequest = async (req, res) => {
 
 exports.listRequests = async (req, res) => {
   try {
-    const snapshot = await db.collection('prayerRequests').get();
+    let query = db.collection('prayerRequests');
+    if (req.query.userId) {
+      query = query.where('userId', '==', req.query.userId);
+    }
+    const snapshot = await query.get();
     const requests = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
     res.json(requests);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.updateRequest = async (req, res) => {
+  const { id } = req.params;
+  const { text, birthday, timeZone, gender } = req.body;
+  if (!text && !birthday && !timeZone && !gender) {
+    return res
+      .status(400)
+      .json({ message: 'text, birthday, timeZone or gender must be provided' });
+  }
+  const updates = {};
+  if (text) updates.text = text;
+  if (birthday !== undefined) {
+    updates.birthday = birthday;
+    Object.assign(updates, computeAgeData(birthday));
+  }
+  if (timeZone !== undefined) updates.timeZone = timeZone;
+  if (gender !== undefined) updates.gender = gender;
+  try {
+    await db.collection('prayerRequests').doc(id).update(updates);
+    res.json({ id, ...updates });
   } catch (err) {
     console.error(err);
     res.status(400).json({ message: err.message });

--- a/src/jobs/prayerCleanup.js
+++ b/src/jobs/prayerCleanup.js
@@ -1,0 +1,20 @@
+const { firestore } = require('../config/firebase');
+const db = firestore;
+
+async function run() {
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const snapshot = await db
+    .collection('prayerRequests')
+    .where('prayedAt', '!=', null)
+    .get();
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    if (data.prayedAt && new Date(data.prayedAt) < sevenDaysAgo) {
+      await doc.ref.delete();
+    }
+  }
+}
+
+run()
+  .then(() => console.log('Prayer request cleanup complete'))
+  .catch((err) => console.error(err));

--- a/src/routes/churches.js
+++ b/src/routes/churches.js
@@ -4,5 +4,7 @@ const controller = require('../controllers/churchesController');
 
 router.post('/', controller.createChurch);
 router.get('/', controller.listChurches);
+router.get('/:id', controller.getChurch);
+router.patch('/:id', controller.updateChurch);
 
 module.exports = router;

--- a/src/routes/prayerRequests.js
+++ b/src/routes/prayerRequests.js
@@ -4,6 +4,7 @@ const controller = require('../controllers/prayerRequestsController');
 
 router.post('/', controller.addRequest);
 router.get('/', controller.listRequests);
+router.patch('/:id', controller.updateRequest);
 router.patch('/:id/prayed', controller.markPrayed);
 
 module.exports = router;

--- a/test/churchesController.test.js
+++ b/test/churchesController.test.js
@@ -1,0 +1,53 @@
+const docGetMock = jest.fn();
+const docUpdateMock = jest.fn();
+const docMock = jest.fn(() => ({ get: docGetMock, update: docUpdateMock }));
+
+const mockFirestore = {
+  collection: jest.fn(() => ({ doc: docMock }))
+};
+
+jest.mock('../src/config/firebase', () => ({ firestore: mockFirestore }));
+
+const controller = require('../src/controllers/churchesController');
+
+function mockResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('churchesController.getChurch', () => {
+  beforeEach(() => {
+    docGetMock.mockReset();
+    docUpdateMock.mockReset();
+    mockFirestore.collection.mockClear();
+    docMock.mockClear();
+  });
+
+  it('returns church data when found', async () => {
+    docGetMock.mockResolvedValue({ exists: true, id: 'c1', data: () => ({ name: 'A', logoUrl: 'logo' }) });
+    const req = { params: { id: 'c1' } };
+    const res = mockResponse();
+    await controller.getChurch(req, res);
+    expect(res.json).toHaveBeenCalledWith({ id: 'c1', name: 'A', logoUrl: 'logo' });
+  });
+});
+
+describe('churchesController.updateChurch', () => {
+  beforeEach(() => {
+    docGetMock.mockReset();
+    docUpdateMock.mockReset();
+    mockFirestore.collection.mockClear();
+    docMock.mockClear();
+  });
+
+  it('updates provided fields', async () => {
+    docUpdateMock.mockResolvedValue();
+    const req = { params: { id: 'c1' }, body: { name: 'New' } };
+    const res = mockResponse();
+    await controller.updateChurch(req, res);
+    expect(docUpdateMock).toHaveBeenCalledWith({ name: 'New' });
+    expect(res.json).toHaveBeenCalledWith({ id: 'c1', name: 'New' });
+  });
+});

--- a/test/prayerRequestsController.test.js
+++ b/test/prayerRequestsController.test.js
@@ -1,0 +1,65 @@
+const listGetMock = jest.fn();
+const whereMock = jest.fn(() => ({ get: listGetMock }));
+const docUpdateMock = jest.fn();
+const docMock = jest.fn(() => ({ update: docUpdateMock }));
+
+const mockFirestore = {
+  collection: jest.fn(() => ({ where: whereMock, get: listGetMock, doc: docMock }))
+};
+
+jest.mock('../src/config/firebase', () => ({ firestore: mockFirestore }));
+
+const controller = require('../src/controllers/prayerRequestsController');
+
+function mockResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('prayerRequestsController.listRequests', () => {
+  beforeEach(() => {
+    listGetMock.mockReset();
+    whereMock.mockClear();
+    mockFirestore.collection.mockClear();
+  });
+
+  it('filters by userId when provided', async () => {
+    listGetMock.mockResolvedValue({ docs: [{ id: 'r1', data: () => ({ userId: 'u1', text: 'hi' }) }] });
+    const req = { query: { userId: 'u1' } };
+    const res = mockResponse();
+    await controller.listRequests(req, res);
+    expect(whereMock).toHaveBeenCalledWith('userId', '==', 'u1');
+    expect(res.json).toHaveBeenCalledWith([{ id: 'r1', userId: 'u1', text: 'hi' }]);
+  });
+});
+
+describe('prayerRequestsController.updateRequest', () => {
+  beforeEach(() => {
+    docUpdateMock.mockReset();
+    docMock.mockClear();
+    mockFirestore.collection.mockClear();
+  });
+
+  it('updates text and recalculates age group', async () => {
+    docUpdateMock.mockResolvedValue();
+    const req = {
+      params: { id: 'r1' },
+      body: { text: 'new', birthday: '2000-01-01' }
+    };
+    const res = mockResponse();
+    await controller.updateRequest(req, res);
+    expect(docUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'new',
+        birthday: '2000-01-01',
+        ageGroup: 'adult',
+        color: 'purple',
+      })
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r1', text: 'new', ageGroup: 'adult', color: 'purple' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- allow churches to retrieve and update their profile
- extend prayer requests with demographics and update/filter options
- add job to purge prayed requests after 7 days

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1c56f92c8327b212a31189b023ca