### PR TITLE
fix: support camelCase prayer request path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ npm test
 - `GET  /api/churches` – List registered churches.
 - `GET  /api/churches/:id` – Retrieve a church profile.
 - `PATCH /api/churches/:id` – Update church name or logo.
-- `POST /api/prayer-requests` – Submit a prayer request with a user ID.
-- `GET  /api/prayer-requests` – List all prayer requests (filter by \`userId\` with query parameter).
-- `PATCH /api/prayer-requests/:id` – Update a prayer request's details.
-- `PATCH /api/prayer-requests/:id/prayed` – Mark a request as prayed for.
+- `POST /api/prayer-requests` – Submit a prayer request with a user ID. Alias: `POST /api/prayerRequests`.
+- `GET  /api/prayer-requests` – List all prayer requests (filter by \`userId\` with query parameter). Alias: `GET /api/prayerRequests`.
+- `PATCH /api/prayer-requests/:id` – Update a prayer request's details. Alias: `PATCH /api/prayerRequests/:id`.
+- `PATCH /api/prayer-requests/:id/prayed` – Mark a request as prayed for. Alias: `PATCH /api/prayerRequests/:id/prayed`.
 - `GET  /api/mentors/:mentorId/children` – List children assigned to a mentor.
 - `POST /api/mentors/records` – Create a mentor progress note.
 - `GET  /api/mentors/:childId/records` – Get notes for a child.

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,8 @@ app.use('/api/groups', groupsRoutes);
 app.use('/api/parent-child', parentChildRoutes);
 app.use('/api/churches', churchesRoutes);
 app.use('/api/prayer-requests', prayerRequestsRoutes);
+// Support camelCase path used by some clients
+app.use('/api/prayerRequests', prayerRequestsRoutes);
 
 app.get('/', (req, res) => {
   res.json({ status: 'Kids Faith Tracker API' });


### PR DESCRIPTION
## Summary
- support `/api/prayerRequests` alongside existing `/api/prayer-requests`
- document both paths in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa36c7c7cc8327aae2ffb01cfeba83