### PR TITLE
feat: add role approval workflow

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3,6 +3,33 @@ info:
   title: Kids Faith Tracker API
   version: 1.0.0
 paths:
+  /api/users/register:
+    post:
+      summary: Register a user with requested role
+      description: Creates a user with a pending role requiring admin approval.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+                name:
+                  type: string
+                role:
+                  type: string
+              required:
+                - email
+                - password
+                - name
+                - role
+      responses:
+        '201':
+          description: Created
   /api/users/register-parent:
     post:
       summary: Register a parent account
@@ -55,6 +82,35 @@ paths:
       responses:
         '200':
           description: User profile
+  /api/users/pending:
+    get:
+      summary: List users pending approval
+      description: Admin role required.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Array of pending users
+  /api/users/approve:
+    post:
+      summary: Approve a pending user
+      description: Admin role required.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                uid:
+                  type: string
+              required:
+                - uid
+      responses:
+        '200':
+          description: User approved
   /api/checkins:
     post:
       summary: Submit a daily check-in

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -1,10 +1,33 @@
 const { admin } = require('../config/firebase');
 const { createChildAccount } = require('../services/childAccountService');
 
+exports.register = async (req, res) => {
+  const { email, password, name, role } = req.body;
+  if (!email || !password || !name || !role) {
+    return res.status(400).json({ message: 'email, password, name, and role are required' });
+  }
+  try {
+    const userRecord = await admin
+      .auth()
+      .createUser({ email, password, displayName: name });
+    await admin
+      .auth()
+      .setCustomUserClaims(userRecord.uid, { role: 'pending', requestedRole: role });
+    res
+      .status(201)
+      .json({ uid: userRecord.uid, email: userRecord.email, requestedRole: role });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+};
+
 exports.registerParent = async (req, res) => {
   const { email, password, name } = req.body;
   try {
-    const userRecord = await admin.auth().createUser({ email, password, displayName: name });
+    const userRecord = await admin
+      .auth()
+      .createUser({ email, password, displayName: name });
     await admin.auth().setCustomUserClaims(userRecord.uid, { role: 'parent' });
     res.status(201).json({ uid: userRecord.uid, email: userRecord.email });
   } catch (err) {
@@ -16,7 +39,9 @@ exports.registerParent = async (req, res) => {
 exports.registerAdmin = async (req, res) => {
   const { email, password, name } = req.body;
   try {
-    const userRecord = await admin.auth().createUser({ email, password, displayName: name });
+    const userRecord = await admin
+      .auth()
+      .createUser({ email, password, displayName: name });
     await admin.auth().setCustomUserClaims(userRecord.uid, { role: 'admin' });
     res.status(201).json({ uid: userRecord.uid, email: userRecord.email });
   } catch (err) {
@@ -70,6 +95,43 @@ exports.listUsers = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: err.message });
+  }
+};
+
+exports.listPendingUsers = async (req, res) => {
+  try {
+    const result = await admin.auth().listUsers();
+    const pending = result.users
+      .filter((u) => u.customClaims?.role === 'pending')
+      .map((u) => ({
+        uid: u.uid,
+        email: u.email,
+        displayName: u.displayName,
+        requestedRole: u.customClaims?.requestedRole || null,
+      }));
+    res.json(pending);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: err.message });
+  }
+};
+
+exports.approveUser = async (req, res) => {
+  const { uid } = req.body;
+  if (!uid) {
+    return res.status(400).json({ message: 'uid is required' });
+  }
+  try {
+    const user = await admin.auth().getUser(uid);
+    const requestedRole = user.customClaims?.requestedRole;
+    if (!requestedRole) {
+      return res.status(400).json({ message: 'No requested role found' });
+    }
+    await admin.auth().setCustomUserClaims(uid, { role: requestedRole });
+    res.json({ uid, role: requestedRole });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
   }
 };
 

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -5,6 +5,7 @@ const usersController = require('../controllers/usersController');
 
 const router = express.Router();
 
+router.post('/register', usersController.register);
 router.post('/register-parent', usersController.registerParent);
 router.post('/register-admin', usersController.registerAdmin);
 router.post('/add-child', auth, roleGuard(['parent']), usersController.addChild);
@@ -12,5 +13,7 @@ router.get('/me', auth, usersController.getMe);
 router.post('/set-admin', auth, roleGuard(['admin']), usersController.setAdminRole);
 router.post('/assign-role', auth, roleGuard(['admin']), usersController.assignRole);
 router.get('/', auth, roleGuard(['admin']), usersController.listUsers);
+router.get('/pending', auth, roleGuard(['admin']), usersController.listPendingUsers);
+router.post('/approve', auth, roleGuard(['admin']), usersController.approveUser);
 
 module.exports = router;

--- a/test/usersController.test.js
+++ b/test/usersController.test.js
@@ -1,11 +1,23 @@
 const mockSetClaims = jest.fn().mockResolvedValue();
+const mockCreateUser = jest
+  .fn()
+  .mockResolvedValue({ uid: 'u1', email: 'user@example.com' });
+const mockListUsers = jest.fn().mockResolvedValue({ users: [] });
+const mockGetUser = jest.fn().mockResolvedValue({});
 
 jest.mock('../src/services/childAccountService', () => ({
   createChildAccount: jest.fn(),
 }));
 
 jest.mock('../src/config/firebase', () => ({
-  admin: { auth: () => ({ setCustomUserClaims: mockSetClaims }) },
+  admin: {
+    auth: () => ({
+      setCustomUserClaims: mockSetClaims,
+      createUser: mockCreateUser,
+      listUsers: mockListUsers,
+      getUser: mockGetUser,
+    }),
+  },
 }));
 
 const { createChildAccount } = require('../src/services/childAccountService');
@@ -74,5 +86,98 @@ describe('usersController.assignRole', () => {
 
     expect(mockSetClaims).toHaveBeenCalledWith('user1', { role: 'mentor' });
     expect(res.json).toHaveBeenCalledWith({ uid: 'user1', role: 'mentor' });
+  });
+});
+
+describe('usersController.register', () => {
+  beforeEach(() => {
+    mockCreateUser.mockClear();
+    mockSetClaims.mockClear();
+  });
+
+  it('creates user with pending role and requested role stored', async () => {
+    const req = {
+      body: {
+        email: 'new@example.com',
+        password: 'pass',
+        name: 'New User',
+        role: 'mentor',
+      },
+    };
+    const res = mockResponse();
+
+    await usersController.register(req, res);
+
+    expect(mockCreateUser).toHaveBeenCalledWith({
+      email: 'new@example.com',
+      password: 'pass',
+      displayName: 'New User',
+    });
+    expect(mockSetClaims).toHaveBeenCalledWith('u1', {
+      role: 'pending',
+      requestedRole: 'mentor',
+    });
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      uid: 'u1',
+      email: 'user@example.com',
+      requestedRole: 'mentor',
+    });
+  });
+});
+
+describe('usersController.listPendingUsers', () => {
+  beforeEach(() => {
+    mockListUsers.mockClear();
+  });
+
+  it('returns only users with pending role', async () => {
+    mockListUsers.mockResolvedValue({
+      users: [
+        {
+          uid: 'p1',
+          email: 'p1@example.com',
+          displayName: 'Pending',
+          customClaims: { role: 'pending', requestedRole: 'mentor' },
+        },
+        { uid: 'u2', email: 'u2@example.com', customClaims: { role: 'child' } },
+      ],
+    });
+
+    const req = {};
+    const res = mockResponse();
+
+    await usersController.listPendingUsers(req, res);
+
+    expect(res.json).toHaveBeenCalledWith([
+      {
+        uid: 'p1',
+        email: 'p1@example.com',
+        displayName: 'Pending',
+        requestedRole: 'mentor',
+      },
+    ]);
+  });
+});
+
+describe('usersController.approveUser', () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockSetClaims.mockClear();
+  });
+
+  it('sets requested role as active role', async () => {
+    mockGetUser.mockResolvedValue({
+      customClaims: { requestedRole: 'mentor' },
+    });
+
+    const req = { body: { uid: 'u1' } };
+    const res = mockResponse();
+
+    await usersController.approveUser(req, res);
+
+    expect(mockGetUser).toHaveBeenCalledWith('u1');
+    expect(mockSetClaims).toHaveBeenCalledWith('u1', { role: 'mentor' });
+    expect(res.json).toHaveBeenCalledWith({ uid: 'u1', role: 'mentor' });
   });
 });


### PR DESCRIPTION
## Summary
- allow users to request roles during registration
- add admin endpoints to list and approve pending registrations
- document new workflow and test role approval

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab29c3e16c83278e73ff87dde06cae